### PR TITLE
Move tests to CI, add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install ${{ matrix.python-version }}
+      - run: uv sync --no-dev
+      - run: uv pip install pytest
+      - run: uv run pytest -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,3 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
-
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: python -m pytest
-        language: system
-        types: [python]
-        pass_filenames: false
-        always_run: true


### PR DESCRIPTION
## Summary
- Remove pytest from pre-commit hooks (keep it fast — linting and formatting only)
- Add GitHub Actions CI workflow that runs on push to main and PRs
- Lint job: ruff check + format check
- Test job: pytest across Python 3.12 and 3.13

## Test plan
- [ ] Check that CI runs and both jobs pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)