### PR TITLE
Index module-level constants, type aliases, and unannotated class vars

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -1,9 +1,14 @@
 src/:
   uncoded/:
     claude_md.py:
+      MARKER_START:
+      MARKER_END:
+      DEFAULT_CLAUDE_MD:
+      SECTION:
       generate_section:
       sync_claude_md:
     cli.py:
+      DEFAULT_MAP_OUTPUT:
       main:
     config.py:
       find_pyproject_toml:
@@ -15,6 +20,7 @@ src/:
         methods:
       ModuleInfo:
         rel_path:
+        constants:
         classes:
         functions:
       is_public:
@@ -25,6 +31,8 @@ src/:
       build_map:
       render_map:
     stubs.py:
+      VALUE_WIDTH_CAP:
+      DEFAULT_STUBS_OUTPUT:
       StubParam:
         name:
         annotation:
@@ -36,6 +44,13 @@ src/:
         start_line:
         end_line:
         is_async:
+      StubAssignment:
+        name:
+        annotation:
+        value_source:
+        start_line:
+        end_line:
+        is_type_alias:
       StubClass:
         name:
         bases:
@@ -47,6 +62,7 @@ src/:
       StubModule:
         rel_path:
         imports:
+        constants:
         classes:
         functions:
       extract_stub:
@@ -80,11 +96,19 @@ tests/:
       test_private_name:
       test_dunder_name:
       test_name_mangled:
+      test_dunder_all_is_public:
+      test_dunder_version_is_public:
     TestExtractModule:
       test_classes_and_functions:
       test_async_functions_and_methods:
       test_empty_module:
       test_only_private_symbols:
+      test_module_level_constants:
+      test_type_alias_classic:
+      test_type_alias_pep695:
+      test_tuple_unpacking_skipped:
+      test_unannotated_class_variable:
+      test_module_with_only_constants_is_kept:
       test_annotated_attributes:
       test_class_with_no_public_members:
       test_preserves_source_order:
@@ -104,6 +128,8 @@ tests/:
       test_function_is_none:
       test_class_with_no_members:
       test_source_order_preserved:
+      test_module_level_constants:
+      test_constants_precede_classes_and_functions:
     TestRenderMap:
       test_roundtrips_through_yaml:
       test_preserves_insertion_order:
@@ -124,6 +150,15 @@ tests/:
       test_imports_collected:
       test_syntax_error_raises:
       test_source_order_preserved:
+      test_constant_annotated_with_value:
+      test_constant_unannotated_with_value:
+      test_constant_bare_annotation:
+      test_constant_value_too_long_elided:
+      test_constant_private_included:
+      test_type_alias_classic:
+      test_type_alias_pep695:
+      test_tuple_unpacking_skipped:
+      test_class_with_unannotated_attribute:
     TestRenderStub:
       test_header_contains_path:
       test_imports_rendered:
@@ -132,9 +167,17 @@ tests/:
       test_function_with_annotations:
       test_docstring_excerpt_rendered:
       test_class_with_bases:
+      test_class_single_line_range:
+      test_function_single_line_range:
       test_class_no_bases:
       test_attribute_with_annotation:
       test_method_indented:
       test_ends_with_newline:
+      test_constant_with_value_rendered:
+      test_constant_annotated_with_value_rendered:
+      test_constant_elided_rendered:
+      test_constant_bare_annotation_rendered:
+      test_type_alias_pep695_rendered:
+      test_unannotated_class_attribute_rendered:
   test_uncoded.py:
     test_import:

--- a/.uncoded/stubs/src/uncoded/claude_md.pyi
+++ b/.uncoded/stubs/src/uncoded/claude_md.pyi
@@ -5,17 +5,17 @@ from pathlib import Path
 MARKER_START = '<!-- uncoded:start -->'  # L5
 MARKER_END = '<!-- uncoded:end -->'  # L6
 DEFAULT_CLAUDE_MD = Path('CLAUDE.md')  # L8
-_SECTION_BODY = ...  # L10-41
-SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L43
+_SECTION_BODY = ...  # L10-46
+SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L48
 
-def generate_section() -> str:  # L46-48
+def generate_section() -> str:  # L51-53
     """Return the full delimited uncoded section for insertion into CLAUDE.md."""
     ...
 
-def _replace_or_append(existing: str, section: str) -> str:  # L51-61
+def _replace_or_append(existing: str, section: str) -> str:  # L56-66
     """Replace the delimited section in existing text, or append it if absent."""
     ...
 
-def sync_claude_md(path: Path) -> None:  # L64-75
+def sync_claude_md(path: Path) -> None:  # L69-80
     """Write or update the uncoded navigation section in CLAUDE.md."""
     ...

--- a/.uncoded/stubs/src/uncoded/claude_md.pyi
+++ b/.uncoded/stubs/src/uncoded/claude_md.pyi
@@ -2,6 +2,12 @@
 
 from pathlib import Path
 
+MARKER_START = '<!-- uncoded:start -->'  # L5
+MARKER_END = '<!-- uncoded:end -->'  # L6
+DEFAULT_CLAUDE_MD = Path('CLAUDE.md')  # L8
+_SECTION_BODY = ...  # L10-41
+SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L43
+
 def generate_section() -> str:  # L46-48
     """Return the full delimited uncoded section for insertion into CLAUDE.md."""
     ...

--- a/.uncoded/stubs/src/uncoded/claude_md.pyi
+++ b/.uncoded/stubs/src/uncoded/claude_md.pyi
@@ -5,17 +5,17 @@ from pathlib import Path
 MARKER_START = '<!-- uncoded:start -->'  # L5
 MARKER_END = '<!-- uncoded:end -->'  # L6
 DEFAULT_CLAUDE_MD = Path('CLAUDE.md')  # L8
-_SECTION_BODY = ...  # L10-46
-SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L48
+_SECTION_BODY = ...  # L10-58
+SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L60
 
-def generate_section() -> str:  # L51-53
+def generate_section() -> str:  # L63-65
     """Return the full delimited uncoded section for insertion into CLAUDE.md."""
     ...
 
-def _replace_or_append(existing: str, section: str) -> str:  # L56-66
+def _replace_or_append(existing: str, section: str) -> str:  # L68-78
     """Replace the delimited section in existing text, or append it if absent."""
     ...
 
-def sync_claude_md(path: Path) -> None:  # L69-80
+def sync_claude_md(path: Path) -> None:  # L81-92
     """Write or update the uncoded navigation section in CLAUDE.md."""
     ...

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -8,6 +8,8 @@ from uncoded.extract import walk_source
 from uncoded.namespace_map import build_map, render_map
 from uncoded.stubs import build_stubs
 
+DEFAULT_MAP_OUTPUT = Path('.uncoded/namespace.yaml')  # L12
+
 def main() -> int:  # L15-38
     """Build the namespace map, stub files, and CLAUDE.md navigation section."""
     ...

--- a/.uncoded/stubs/src/uncoded/extract.pyi
+++ b/.uncoded/stubs/src/uncoded/extract.pyi
@@ -5,19 +5,25 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-def is_public(name: str) -> bool:  # L27-29
-    """A name is public if it has no leading underscore."""
+_DUNDER_PUBLIC = frozenset({'__all__', '__version__'})  # L29
+
+def is_public(name: str) -> bool:  # L32-36
+    """A name is public if it has no leading underscore (or is a public dunder)."""
     ...
 
-def extract_module(source: str, rel_path: str) -> ModuleInfo:  # L32-62
-    """Parse Python source and extract public classes and functions."""
+def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:  # L39-47
+    """Return the single-name target of an assignment, or None if not a simple name."""
     ...
 
-def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[str, str]]:  # L65-92
+def extract_module(source: str, rel_path: str) -> ModuleInfo:  # L50-93
+    """Parse Python source and extract public classes, functions, and constants."""
+    ...
+
+def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[str, str]]:  # L96-123
     """Yield (source_text, rel_path) for each candidate Python file."""
     ...
 
-def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:  # L95-116
+def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:  # L126-147
     """Walk a source root and extract public symbols from all packages."""
     ...
 
@@ -25,12 +31,13 @@ class ClassInfo:  # L10-15
     """A public class with its public attributes and methods."""
 
     name: str
-    attributes: list[str]
-    methods: list[str]
+    attributes: list[str] = field(default_factory=list)
+    methods: list[str] = field(default_factory=list)
 
-class ModuleInfo:  # L19-24
+class ModuleInfo:  # L19-25
     """Public symbols found in a single Python module."""
 
     rel_path: str
-    classes: list[ClassInfo]
-    functions: list[str]
+    constants: list[str] = field(default_factory=list)
+    classes: list[ClassInfo] = field(default_factory=list)
+    functions: list[str] = field(default_factory=list)

--- a/.uncoded/stubs/src/uncoded/namespace_map.pyi
+++ b/.uncoded/stubs/src/uncoded/namespace_map.pyi
@@ -4,11 +4,11 @@ from pathlib import Path
 import yaml
 from uncoded.extract import ModuleInfo
 
-def build_map(modules: list[ModuleInfo]) -> dict:  # L25-58
+def build_map(modules: list[ModuleInfo]) -> dict:  # L25-61
     """Build a nested dict representing the namespace."""
     ...
 
-def render_map(namespace: dict) -> str:  # L61-68
+def render_map(namespace: dict) -> str:  # L64-71
     """Render a namespace map dict as a YAML string."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -6,78 +6,116 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from uncoded.extract import iter_source_files
 
-def _first_sentence(node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module) -> str | None:  # L55-66
+VALUE_WIDTH_CAP = 80  # L12
+DEFAULT_STUBS_OUTPUT = Path('.uncoded/stubs')  # L350
+
+def _first_sentence(node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module) -> str | None:  # L77-88
     """Return the first sentence of a node's docstring, or None."""
     ...
 
-def _extract_params(args: ast.arguments) -> list[StubParam]:  # L69-101
+def _extract_params(args: ast.arguments) -> list[StubParam]:  # L91-123
     """Extract parameters from a function argument node, without defaults."""
     ...
 
-def _extract_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubFunction:  # L104-116
+def _line_range(start: int, end: int) -> str:  # L126-128
+    """Render a line range: 'L<start>' if single-line, else 'L<start>-<end>'."""
+    ...
+
+def _render_value(value: ast.expr) -> str:  # L131-136
+    """Render an expression as source, eliding to '...' if too long or multi-line."""
+    ...
+
+def _extract_assignment(node: ast.Assign | ast.AnnAssign | ast.TypeAlias) -> StubAssignment | None:  # L139-182
+    """Build a StubAssignment from an assignment-style AST node."""
+    ...
+
+def _extract_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubFunction:  # L185-197
     """Build a StubFunction from a function or method AST node."""
     ...
 
-def _extract_class(node: ast.ClassDef) -> StubClass:  # L119-141
+def _extract_class(node: ast.ClassDef) -> StubClass:  # L200-223
     """Build a StubClass from a class AST node."""
     ...
 
-def extract_stub(source: str, rel_path: str) -> StubModule:  # L144-161
+def extract_stub(source: str, rel_path: str) -> StubModule:  # L226-252
     """Parse Python source and extract all symbols with signatures and line ranges."""
     ...
 
-def _render_param(p: StubParam) -> str:  # L164-170
+def _render_param(p: StubParam) -> str:  # L255-261
     """Render a single parameter as a string for a function signature."""
     ...
 
-def _render_function(func: StubFunction, indent: str) -> list[str]:  # L173-184
+def _render_function(func: StubFunction, indent: str) -> list[str]:  # L264-275
     """Render a function or method as stub lines, indented for methods."""
     ...
 
-def render_stub(module: StubModule) -> str:  # L187-220
+def _format_assignment_body(a: StubAssignment) -> str:  # L278-285
+    """Render the 'name [: type] [= value]' portion of an assignment."""
+    ...
+
+def _render_assignment(a: StubAssignment, indent: str) -> str:  # L288-291
+    """Render a module-level assignment as a stub line, with line range."""
+    ...
+
+def _render_class_attribute(a: StubAssignment, indent: str) -> str:  # L294-296
+    """Render a class attribute as a stub line (no line range — class has one)."""
+    ...
+
+def render_stub(module: StubModule) -> str:  # L299-333
     """Render a StubModule as a .pyi file string."""
     ...
 
-def _generate_stubs(source_root: Path) -> dict[Path, str]:  # L223-234
+def _generate_stubs(source_root: Path) -> dict[Path, str]:  # L336-347
     """Return a mapping from stub relative paths to rendered stub content."""
     ...
 
-def build_stubs(source_root: Path, output_dir: Path) -> None:  # L240-246
+def build_stubs(source_root: Path, output_dir: Path) -> None:  # L353-359
     """Write stub files for all symbols under source_root."""
     ...
 
-class StubParam:  # L12-16
+class StubParam:  # L16-20
     """A function parameter with name and optional type annotation."""
 
     name: str
-    annotation: str | None
+    annotation: str | None = None
 
-class StubFunction:  # L20-29
+class StubFunction:  # L24-33
     """A function or method with its signature and line range."""
 
     name: str
-    params: list[StubParam]
-    return_annotation: str | None
-    docstring_excerpt: str | None
-    start_line: int
-    end_line: int
-    is_async: bool
+    params: list[StubParam] = field(default_factory=list)
+    return_annotation: str | None = None
+    docstring_excerpt: str | None = None
+    start_line: int = 0
+    end_line: int = 0
+    is_async: bool = False
 
-class StubClass:  # L33-42
+class StubAssignment:  # L37-50
+    """A module-level or class-level assignment."""
+
+    name: str
+    annotation: str | None = None
+    value_source: str | None = None
+    start_line: int = 0
+    end_line: int = 0
+    is_type_alias: bool = False
+
+class StubClass:  # L54-63
     """A class with its members and line range."""
 
     name: str
-    bases: list[str]
-    docstring_excerpt: str | None
-    start_line: int
-    end_line: int
-    attributes: list[StubParam]
-    methods: list[StubFunction]
+    bases: list[str] = field(default_factory=list)
+    docstring_excerpt: str | None = None
+    start_line: int = 0
+    end_line: int = 0
+    attributes: list[StubAssignment] = field(default_factory=list)
+    methods: list[StubFunction] = field(default_factory=list)
 
-class StubModule:  # L46-52
+class StubModule:  # L67-74
     """All symbols extracted from a single Python module."""
 
     rel_path: str
-    imports: list[str]
-    classes: list[StubClass]
-    functions: list[StubFunction]
+    imports: list[str] = field(default_factory=list)
+    constants: list[StubAssignment] = field(default_factory=list)
+    classes: list[StubClass] = field(default_factory=list)
+    functions: list[StubFunction] = field(default_factory=list)

--- a/.uncoded/stubs/tests/test_extract.pyi
+++ b/.uncoded/stubs/tests/test_extract.pyi
@@ -3,7 +3,7 @@
 import textwrap
 from uncoded.extract import extract_module, is_public, walk_source
 
-class TestIsPublic:  # L6-20
+class TestIsPublic:  # L6-26
 
     def test_public_name(self):  # L7-8
         ...
@@ -20,45 +20,69 @@ class TestIsPublic:  # L6-20
     def test_name_mangled(self):  # L19-20
         ...
 
-class TestExtractModule:  # L23-152
-
-    def test_classes_and_functions(self):  # L24-50
+    def test_dunder_all_is_public(self):  # L22-23
         ...
 
-    def test_async_functions_and_methods(self):  # L52-69
+    def test_dunder_version_is_public(self):  # L25-26
         ...
 
-    def test_empty_module(self):  # L71-75
+class TestExtractModule:  # L29-224
+
+    def test_classes_and_functions(self):  # L30-56
         ...
 
-    def test_only_private_symbols(self):  # L77-91
+    def test_async_functions_and_methods(self):  # L58-75
         ...
 
-    def test_annotated_attributes(self):  # L93-112
+    def test_empty_module(self):  # L77-81
         ...
 
-    def test_class_with_no_public_members(self):  # L114-131
+    def test_only_private_symbols(self):  # L83-98
         ...
 
-    def test_preserves_source_order(self):  # L133-152
+    def test_module_level_constants(self):  # L100-110
         ...
 
-class TestWalkSource:  # L155-246
-
-    def test_basic_walk(self, tmp_path):  # L156-181
+    def test_type_alias_classic(self):  # L112-120
         ...
 
-    def test_nested_subpackage(self, tmp_path):  # L183-195
+    def test_type_alias_pep695(self):  # L122-130
         ...
 
-    def test_skips_private_subdirectory(self, tmp_path):  # L197-207
+    def test_tuple_unpacking_skipped(self):  # L132-139
         ...
 
-    def test_includes_init_with_public_symbols(self, tmp_path):  # L209-220
+    def test_unannotated_class_variable(self):  # L141-152
         ...
 
-    def test_skips_empty_init(self, tmp_path):  # L222-232
+    def test_module_with_only_constants_is_kept(self, tmp_path):  # L154-163
         ...
 
-    def test_skips_syntax_errors(self, tmp_path):  # L234-246
+    def test_annotated_attributes(self):  # L165-184
+        ...
+
+    def test_class_with_no_public_members(self):  # L186-203
+        ...
+
+    def test_preserves_source_order(self):  # L205-224
+        ...
+
+class TestWalkSource:  # L227-318
+
+    def test_basic_walk(self, tmp_path):  # L228-253
+        ...
+
+    def test_nested_subpackage(self, tmp_path):  # L255-267
+        ...
+
+    def test_skips_private_subdirectory(self, tmp_path):  # L269-279
+        ...
+
+    def test_includes_init_with_public_symbols(self, tmp_path):  # L281-292
+        ...
+
+    def test_skips_empty_init(self, tmp_path):  # L294-304
+        ...
+
+    def test_skips_syntax_errors(self, tmp_path):  # L306-318
         ...

--- a/.uncoded/stubs/tests/test_namespace_map.pyi
+++ b/.uncoded/stubs/tests/test_namespace_map.pyi
@@ -4,7 +4,7 @@ import yaml
 from uncoded.extract import ClassInfo, ModuleInfo
 from uncoded.namespace_map import build_map, render_map
 
-class TestBuildMap:  # L7-116
+class TestBuildMap:  # L7-146
 
     def test_single_file(self):  # L8-23
         ...
@@ -27,13 +27,19 @@ class TestBuildMap:  # L7-116
     def test_source_order_preserved(self):  # L104-116
         ...
 
-class TestRenderMap:  # L119-155
-
-    def test_roundtrips_through_yaml(self):  # L120-133
+    def test_module_level_constants(self):  # L118-131
         ...
 
-    def test_preserves_insertion_order(self):  # L135-144
+    def test_constants_precede_classes_and_functions(self):  # L133-146
         ...
 
-    def test_null_renders_clean(self):  # L146-155
+class TestRenderMap:  # L149-185
+
+    def test_roundtrips_through_yaml(self):  # L150-163
+        ...
+
+    def test_preserves_insertion_order(self):  # L165-174
+        ...
+
+    def test_null_renders_clean(self):  # L176-185
         ...

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -2,83 +2,134 @@
 
 import textwrap
 import pytest
-from uncoded.stubs import StubClass, StubFunction, StubModule, StubParam, extract_stub, render_stub
+from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, extract_stub, render_stub
 
-class TestExtractStub:  # L15-181
+class TestExtractStub:  # L16-271
 
-    def test_simple_function(self):  # L16-30
+    def test_simple_function(self):  # L17-31
         ...
 
-    def test_function_no_annotations(self):  # L32-40
+    def test_function_no_annotations(self):  # L33-41
         ...
 
-    def test_async_function(self):  # L42-50
+    def test_async_function(self):  # L43-51
         ...
 
-    def test_private_function_included(self):  # L52-60
+    def test_private_function_included(self):  # L53-61
         ...
 
-    def test_class_with_attributes_and_methods(self):  # L62-89
+    def test_class_with_attributes_and_methods(self):  # L63-90
         ...
 
-    def test_class_line_range(self):  # L91-107
+    def test_class_line_range(self):  # L92-108
         ...
 
-    def test_class_with_bases(self):  # L109-115
+    def test_class_with_bases(self):  # L110-116
         ...
 
-    def test_class_no_bases(self):  # L117-123
+    def test_class_no_bases(self):  # L118-124
         ...
 
-    def test_docstring_first_sentence_only(self):  # L125-132
+    def test_docstring_first_sentence_only(self):  # L126-133
         ...
 
-    def test_no_docstring(self):  # L134-140
+    def test_no_docstring(self):  # L135-141
         ...
 
-    def test_kwargs_and_varargs(self):  # L142-150
+    def test_kwargs_and_varargs(self):  # L143-151
         ...
 
-    def test_imports_collected(self):  # L152-166
+    def test_imports_collected(self):  # L153-167
         ...
 
-    def test_syntax_error_raises(self):  # L168-170
+    def test_syntax_error_raises(self):  # L169-171
         ...
 
-    def test_source_order_preserved(self):  # L172-181
+    def test_source_order_preserved(self):  # L173-182
         ...
 
-class TestRenderStub:  # L184-297
-
-    def test_header_contains_path(self):  # L185-187
+    def test_constant_annotated_with_value(self):  # L184-194
         ...
 
-    def test_imports_rendered(self):  # L189-195
+    def test_constant_unannotated_with_value(self):  # L196-204
         ...
 
-    def test_function_line_range(self):  # L197-203
+    def test_constant_bare_annotation(self):  # L206-213
         ...
 
-    def test_async_function_prefix(self):  # L205-212
+    def test_constant_value_too_long_elided(self):  # L215-221
         ...
 
-    def test_function_with_annotations(self):  # L214-227
+    def test_constant_private_included(self):  # L223-228
         ...
 
-    def test_docstring_excerpt_rendered(self):  # L229-243
+    def test_type_alias_classic(self):  # L230-240
         ...
 
-    def test_class_with_bases(self):  # L245-250
+    def test_type_alias_pep695(self):  # L242-250
         ...
 
-    def test_class_no_bases(self):  # L252-257
+    def test_tuple_unpacking_skipped(self):  # L252-257
         ...
 
-    def test_attribute_with_annotation(self):  # L259-271
+    def test_class_with_unannotated_attribute(self):  # L259-271
         ...
 
-    def test_method_indented(self):  # L273-293
+class TestRenderStub:  # L274-481
+
+    def test_header_contains_path(self):  # L275-277
         ...
 
-    def test_ends_with_newline(self):  # L295-297
+    def test_imports_rendered(self):  # L279-285
+        ...
+
+    def test_function_line_range(self):  # L287-293
+        ...
+
+    def test_async_function_prefix(self):  # L295-302
+        ...
+
+    def test_function_with_annotations(self):  # L304-317
+        ...
+
+    def test_docstring_excerpt_rendered(self):  # L319-333
+        ...
+
+    def test_class_with_bases(self):  # L335-340
+        ...
+
+    def test_class_single_line_range(self):  # L342-347
+        ...
+
+    def test_function_single_line_range(self):  # L349-354
+        ...
+
+    def test_class_no_bases(self):  # L356-361
+        ...
+
+    def test_attribute_with_annotation(self):  # L363-375
+        ...
+
+    def test_method_indented(self):  # L377-397
+        ...
+
+    def test_ends_with_newline(self):  # L399-401
+        ...
+
+    def test_constant_with_value_rendered(self):  # L403-412
+        ...
+
+    def test_constant_annotated_with_value_rendered(self):  # L414-427
+        ...
+
+    def test_constant_elided_rendered(self):  # L429-438
+        ...
+
+    def test_constant_bare_annotation_rendered(self):  # L440-449
+        ...
+
+    def test_type_alias_pep695_rendered(self):  # L451-464
+        ...
+
+    def test_unannotated_class_attribute_rendered(self):  # L466-481
         ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ tests/test_foo.py   →  .uncoded/stubs/tests/test_foo.pyi
 ```
 
 The stub gives you imports, all signatures with types, first-sentence
-docstrings, and a `L<start>-<end>` line range on every definition —
-including private helpers.
+docstrings, and a `L<start>` or `L<start>-<end>` line range on every
+definition — including private helpers.
 
 **Step 3 — Read.** Use line ranges from the stub to read only what you need:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,21 +78,33 @@ answers will come from pretrained guesses rather than the code actually
 here. The map lists every public symbol in the codebase — directories,
 files, classes, methods, functions — in source order.
 
-**Step 2 — Understand.** For each relevant file, read its stub. The stub path
-mirrors the source path under `.uncoded/stubs/` with a `.pyi` extension:
+**Step 2 — Understand.** Before reading any `.py` source file in this repo,
+read its `.pyi` stub first. Stub paths mirror source paths under
+`.uncoded/stubs/`:
 
 ```
 src/foo/bar.py      →  .uncoded/stubs/src/foo/bar.pyi
 tests/test_foo.py   →  .uncoded/stubs/tests/test_foo.pyi
 ```
 
-The stub gives you imports, all signatures with types, first-sentence
-docstrings, and a `L<start>` or `L<start>-<end>` line range on every
-definition — including private helpers.
+This applies to every file you intend to touch or reference — including
+tests. The stub is sufficient for most navigation: it contains imports,
+every signature with types, first-sentence docstrings, and a `L<start>`
+or `L<start>-<end>` line range on every definition — public and private.
+Skipping to source means reading many lines to learn what the stub would
+have told you in one. If no stub exists at the expected path, the file
+has no public symbols indexed — in that narrow case, read source directly.
 
-**Step 3 — Read.** Use line ranges from the stub to read only what you need:
+**Step 3 — Read source, never without offset and limit.** When you need
+source beyond what the stub shows, use the stub's line range:
 
 ```
 Read src/foo/bar.py  offset=<start>  limit=<end - start + 1>
 ```
+
+Calling Read on a `.py` file without `offset` and `limit` is a protocol
+violation — it means either Step 2 was skipped, or you are reading more
+of the file than the stub said you needed. The one exception is the
+first Read of a stub-less file (see Step 2), which is genuinely
+exploratory.
 <!-- uncoded:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,14 +64,19 @@ pytest
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a navigation index for AI agents. Do not grep. Do not read whole source files.
 
-**Step 1 — Orient.** At the start of every task, read the namespace map in full:
+**Step 1 — Orient. Do this now, before anything else.** Your first action
+in this session — before answering the user, before any other tool call —
+is to read the namespace map in full:
 
 ```
 Read .uncoded/namespace.yaml
 ```
 
-This lists every public symbol in the codebase — directories, files, classes,
-methods, functions — in source order.
+Do this once, immediately, at session start — not "eventually" or "when
+a code question comes up." Without the map loaded, design and navigation
+answers will come from pretrained guesses rather than the code actually
+here. The map lists every public symbol in the codebase — directories,
+files, classes, methods, functions — in source order.
 
 **Step 2 — Understand.** For each relevant file, read its stub. The stub path
 mirrors the source path under `.uncoded/stubs/` with a `.pyi` extension:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ pytest
 ```
 
 <!-- uncoded:start -->
-## uncoded navigation index
+## How to navigate this codebase and read source files
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a navigation index for AI agents. Do not grep. Do not read whole source files.

--- a/src/uncoded/claude_md.py
+++ b/src/uncoded/claude_md.py
@@ -31,8 +31,8 @@ tests/test_foo.py   →  .uncoded/stubs/tests/test_foo.pyi
 ```
 
 The stub gives you imports, all signatures with types, first-sentence
-docstrings, and a `L<start>-<end>` line range on every definition —
-including private helpers.
+docstrings, and a `L<start>` or `L<start>-<end>` line range on every
+definition — including private helpers.
 
 **Step 3 — Read.** Use line ranges from the stub to read only what you need:
 

--- a/src/uncoded/claude_md.py
+++ b/src/uncoded/claude_md.py
@@ -13,14 +13,19 @@ _SECTION_BODY = """\
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a navigation index for AI agents. Do not grep. Do not read whole source files.
 
-**Step 1 — Orient.** At the start of every task, read the namespace map in full:
+**Step 1 — Orient. Do this now, before anything else.** Your first action
+in this session — before answering the user, before any other tool call —
+is to read the namespace map in full:
 
 ```
 Read .uncoded/namespace.yaml
 ```
 
-This lists every public symbol in the codebase — directories, files, classes,
-methods, functions — in source order.
+Do this once, immediately, at session start — not "eventually" or "when
+a code question comes up." Without the map loaded, design and navigation
+answers will come from pretrained guesses rather than the code actually
+here. The map lists every public symbol in the codebase — directories,
+files, classes, methods, functions — in source order.
 
 **Step 2 — Understand.** For each relevant file, read its stub. The stub path
 mirrors the source path under `.uncoded/stubs/` with a `.pyi` extension:

--- a/src/uncoded/claude_md.py
+++ b/src/uncoded/claude_md.py
@@ -8,7 +8,7 @@ MARKER_END = "<!-- uncoded:end -->"
 DEFAULT_CLAUDE_MD = Path("CLAUDE.md")
 
 _SECTION_BODY = """\
-## uncoded navigation index
+## How to navigate this codebase and read source files
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a navigation index for AI agents. Do not grep. Do not read whole source files.

--- a/src/uncoded/claude_md.py
+++ b/src/uncoded/claude_md.py
@@ -27,23 +27,35 @@ answers will come from pretrained guesses rather than the code actually
 here. The map lists every public symbol in the codebase — directories,
 files, classes, methods, functions — in source order.
 
-**Step 2 — Understand.** For each relevant file, read its stub. The stub path
-mirrors the source path under `.uncoded/stubs/` with a `.pyi` extension:
+**Step 2 — Understand.** Before reading any `.py` source file in this repo,
+read its `.pyi` stub first. Stub paths mirror source paths under
+`.uncoded/stubs/`:
 
 ```
 src/foo/bar.py      →  .uncoded/stubs/src/foo/bar.pyi
 tests/test_foo.py   →  .uncoded/stubs/tests/test_foo.pyi
 ```
 
-The stub gives you imports, all signatures with types, first-sentence
-docstrings, and a `L<start>` or `L<start>-<end>` line range on every
-definition — including private helpers.
+This applies to every file you intend to touch or reference — including
+tests. The stub is sufficient for most navigation: it contains imports,
+every signature with types, first-sentence docstrings, and a `L<start>`
+or `L<start>-<end>` line range on every definition — public and private.
+Skipping to source means reading many lines to learn what the stub would
+have told you in one. If no stub exists at the expected path, the file
+has no public symbols indexed — in that narrow case, read source directly.
 
-**Step 3 — Read.** Use line ranges from the stub to read only what you need:
+**Step 3 — Read source, never without offset and limit.** When you need
+source beyond what the stub shows, use the stub's line range:
 
 ```
 Read src/foo/bar.py  offset=<start>  limit=<end - start + 1>
-```"""
+```
+
+Calling Read on a `.py` file without `offset` and `limit` is a protocol
+violation — it means either Step 2 was skipped, or you are reading more
+of the file than the stub said you needed. The one exception is the
+first Read of a stub-less file (see Step 2), which is genuinely
+exploratory."""
 
 SECTION = f"{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n"
 

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -20,31 +20,50 @@ class ModuleInfo:
     """Public symbols found in a single Python module."""
 
     rel_path: str
+    constants: list[str] = field(default_factory=list)
     classes: list[ClassInfo] = field(default_factory=list)
     functions: list[str] = field(default_factory=list)
 
 
+# Dunders treated as public — conventional module-level public API.
+_DUNDER_PUBLIC = frozenset({"__all__", "__version__"})
+
+
 def is_public(name: str) -> bool:
-    """A name is public if it has no leading underscore."""
+    """A name is public if it has no leading underscore (or is a public dunder)."""
+    if name in _DUNDER_PUBLIC:
+        return True
     return not name.startswith("_")
 
 
+def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:
+    """Return the single-name target of an assignment, or None if not a simple name."""
+    if isinstance(node, ast.AnnAssign):
+        target = node.target
+        return target.id if isinstance(target, ast.Name) else None
+    if len(node.targets) != 1:
+        return None
+    target = node.targets[0]
+    return target.id if isinstance(target, ast.Name) else None
+
+
 def extract_module(source: str, rel_path: str) -> ModuleInfo:
-    """Parse Python source and extract public classes and functions."""
+    """Parse Python source and extract public classes, functions, and constants."""
     tree = ast.parse(source)
 
+    constants: list[str] = []
     classes: list[ClassInfo] = []
     functions: list[str] = []
 
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.ClassDef) and is_public(node.name):
-            attributes = [
-                n.target.id
-                for n in ast.iter_child_nodes(node)
-                if isinstance(n, ast.AnnAssign)
-                and isinstance(n.target, ast.Name)
-                and is_public(n.target.id)
-            ]
+            attributes: list[str] = []
+            for n in ast.iter_child_nodes(node):
+                name = None
+                if isinstance(n, (ast.AnnAssign, ast.Assign)):
+                    name = _assign_target_name(n)
+                if name and is_public(name):
+                    attributes.append(name)
             methods = [
                 n.name
                 for n in ast.iter_child_nodes(node)
@@ -58,8 +77,20 @@ def extract_module(source: str, rel_path: str) -> ModuleInfo:
             node.name
         ):
             functions.append(node.name)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            name = _assign_target_name(node)
+            if name and is_public(name):
+                constants.append(name)
+        elif isinstance(node, ast.TypeAlias) and isinstance(node.name, ast.Name):
+            if is_public(node.name.id):
+                constants.append(node.name.id)
 
-    return ModuleInfo(rel_path=rel_path, classes=classes, functions=functions)
+    return ModuleInfo(
+        rel_path=rel_path,
+        constants=constants,
+        classes=classes,
+        functions=functions,
+    )
 
 
 def iter_source_files(
@@ -110,7 +141,7 @@ def walk_source(source_root: Path, base: Path | None = None) -> list[ModuleInfo]
         except SyntaxError:
             continue
 
-        if module.classes or module.functions:
+        if module.classes or module.functions or module.constants:
             modules.append(module)
 
     return modules

--- a/src/uncoded/namespace_map.py
+++ b/src/uncoded/namespace_map.py
@@ -43,8 +43,11 @@ def build_map(modules: list[ModuleInfo]) -> dict:
 
         # Build the file entry — symbols directly under the file key.
         # Classes with methods map to their method list.
-        # Classes without methods and bare functions map to None.
+        # Classes without methods, bare functions, and constants map to None.
         file_entry: dict = {}
+
+        for const in module.constants:
+            file_entry[const] = None
 
         for cls in module.classes:
             members = cls.attributes + cls.methods

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -7,6 +7,10 @@ from pathlib import Path
 
 from uncoded.extract import iter_source_files
 
+# Width cap for inlining the right-hand side of an assignment. If the unparsed
+# RHS exceeds this, it is elided to "..." and the reader follows the line range.
+VALUE_WIDTH_CAP = 80
+
 
 @dataclass
 class StubParam:
@@ -30,6 +34,23 @@ class StubFunction:
 
 
 @dataclass
+class StubAssignment:
+    """A module-level or class-level assignment.
+
+    ``value_source`` is the rendered RHS if it fits within ``VALUE_WIDTH_CAP``,
+    or the literal string ``"..."`` if the RHS was elided. ``None`` means there
+    is no RHS at all (e.g. a bare annotation ``X: int``).
+    """
+
+    name: str
+    annotation: str | None = None
+    value_source: str | None = None
+    start_line: int = 0
+    end_line: int = 0
+    is_type_alias: bool = False
+
+
+@dataclass
 class StubClass:
     """A class with its members and line range."""
 
@@ -38,7 +59,7 @@ class StubClass:
     docstring_excerpt: str | None = None
     start_line: int = 0
     end_line: int = 0
-    attributes: list[StubParam] = field(default_factory=list)
+    attributes: list[StubAssignment] = field(default_factory=list)
     methods: list[StubFunction] = field(default_factory=list)
 
 
@@ -48,6 +69,7 @@ class StubModule:
 
     rel_path: str
     imports: list[str] = field(default_factory=list)
+    constants: list[StubAssignment] = field(default_factory=list)
     classes: list[StubClass] = field(default_factory=list)
     functions: list[StubFunction] = field(default_factory=list)
 
@@ -101,6 +123,65 @@ def _extract_params(args: ast.arguments) -> list[StubParam]:
     return params
 
 
+def _line_range(start: int, end: int) -> str:
+    """Render a line range: 'L<start>' if single-line, else 'L<start>-<end>'."""
+    return f"L{start}" if start == end else f"L{start}-{end}"
+
+
+def _render_value(value: ast.expr) -> str:
+    """Render an expression as source, eliding to '...' if too long or multi-line."""
+    source = ast.unparse(value)
+    if len(source) > VALUE_WIDTH_CAP or "\n" in source:
+        return "..."
+    return source
+
+
+def _extract_assignment(
+    node: ast.Assign | ast.AnnAssign | ast.TypeAlias,
+) -> StubAssignment | None:
+    """Build a StubAssignment from an assignment-style AST node.
+
+    Returns None if the node's target is not a single simple name (e.g. tuple
+    unpacking or attribute assignment), which we can't represent cleanly.
+    """
+    start_line = node.lineno
+    end_line = node.end_lineno or node.lineno
+
+    if isinstance(node, ast.TypeAlias):
+        if not isinstance(node.name, ast.Name):
+            return None
+        return StubAssignment(
+            name=node.name.id,
+            value_source=_render_value(node.value),
+            start_line=start_line,
+            end_line=end_line,
+            is_type_alias=True,
+        )
+
+    if isinstance(node, ast.AnnAssign):
+        if not isinstance(node.target, ast.Name):
+            return None
+        annotation = ast.unparse(node.annotation)
+        value_source = _render_value(node.value) if node.value is not None else None
+        return StubAssignment(
+            name=node.target.id,
+            annotation=annotation,
+            value_source=value_source,
+            start_line=start_line,
+            end_line=end_line,
+        )
+
+    # ast.Assign
+    if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+        return None
+    return StubAssignment(
+        name=node.targets[0].id,
+        value_source=_render_value(node.value),
+        start_line=start_line,
+        end_line=end_line,
+    )
+
+
 def _extract_function(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
 ) -> StubFunction:
@@ -120,13 +201,14 @@ def _extract_class(node: ast.ClassDef) -> StubClass:
     """Build a StubClass from a class AST node."""
     bases = [ast.unparse(b) for b in node.bases]
 
-    attributes: list[StubParam] = []
+    attributes: list[StubAssignment] = []
     methods: list[StubFunction] = []
 
     for child in ast.iter_child_nodes(node):
-        if isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name):
-            annotation = ast.unparse(child.annotation) if child.annotation else None
-            attributes.append(StubParam(name=child.target.id, annotation=annotation))
+        if isinstance(child, (ast.AnnAssign, ast.Assign)):
+            assignment = _extract_assignment(child)
+            if assignment is not None:
+                attributes.append(assignment)
         elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             methods.append(_extract_function(child))
 
@@ -145,6 +227,7 @@ def extract_stub(source: str, rel_path: str) -> StubModule:
     """Parse Python source and extract all symbols with signatures and line ranges."""
     tree = ast.parse(source)
     imports: list[str] = []
+    constants: list[StubAssignment] = []
     classes: list[StubClass] = []
     functions: list[StubFunction] = []
 
@@ -155,9 +238,17 @@ def extract_stub(source: str, rel_path: str) -> StubModule:
             classes.append(_extract_class(node))
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             functions.append(_extract_function(node))
+        elif isinstance(node, (ast.Assign, ast.AnnAssign, ast.TypeAlias)):
+            assignment = _extract_assignment(node)
+            if assignment is not None:
+                constants.append(assignment)
 
     return StubModule(
-        rel_path=rel_path, imports=imports, classes=classes, functions=functions
+        rel_path=rel_path,
+        imports=imports,
+        constants=constants,
+        classes=classes,
+        functions=functions,
     )
 
 
@@ -176,12 +267,33 @@ def _render_function(func: StubFunction, indent: str = "") -> list[str]:
     ret = f" -> {func.return_annotation}" if func.return_annotation else ""
     prefix = "async def" if func.is_async else "def"
     lines = [
-        f"{indent}{prefix} {func.name}({params_str}){ret}:  # L{func.start_line}-{func.end_line}"  # noqa: E501
+        f"{indent}{prefix} {func.name}({params_str}){ret}:  # {_line_range(func.start_line, func.end_line)}"  # noqa: E501
     ]
     if func.docstring_excerpt:
         lines.append(f'{indent}    """{func.docstring_excerpt}"""')
     lines.append(f"{indent}    ...")
     return lines
+
+
+def _format_assignment_body(a: StubAssignment) -> str:
+    """Render the 'name [: type] [= value]' portion of an assignment."""
+    if a.is_type_alias:
+        return f"type {a.name} = {a.value_source}"
+    head = f"{a.name}: {a.annotation}" if a.annotation else a.name
+    if a.value_source is None:
+        return head
+    return f"{head} = {a.value_source}"
+
+
+def _render_assignment(a: StubAssignment, indent: str = "") -> str:
+    """Render a module-level assignment as a stub line, with line range."""
+    body = _format_assignment_body(a)
+    return f"{indent}{body}  # {_line_range(a.start_line, a.end_line)}"
+
+
+def _render_class_attribute(a: StubAssignment, indent: str = "    ") -> str:
+    """Render a class attribute as a stub line (no line range — class has one)."""
+    return f"{indent}{_format_assignment_body(a)}"
 
 
 def render_stub(module: StubModule) -> str:
@@ -192,24 +304,25 @@ def render_stub(module: StubModule) -> str:
         lines.extend(module.imports)
         lines.append("")
 
+    for const in module.constants:
+        lines.append(_render_assignment(const))
+    if module.constants:
+        lines.append("")
+
     for func in module.functions:
         lines.extend(_render_function(func))
         lines.append("")
 
     for cls in module.classes:
         bases_str = f"({', '.join(cls.bases)})" if cls.bases else ""
-        lines.append(
-            f"class {cls.name}{bases_str}:  # L{cls.start_line}-{cls.end_line}"
-        )
+        range_str = _line_range(cls.start_line, cls.end_line)
+        lines.append(f"class {cls.name}{bases_str}:  # {range_str}")
         if cls.docstring_excerpt:
             lines.append(f'    """{cls.docstring_excerpt}"""')
         lines.append("")
 
         for attr in cls.attributes:
-            if attr.annotation:
-                lines.append(f"    {attr.name}: {attr.annotation}")
-            else:
-                lines.append(f"    {attr.name}")
+            lines.append(_render_class_attribute(attr))
         if cls.attributes:
             lines.append("")
 
@@ -228,7 +341,7 @@ def _generate_stubs(source_root: Path) -> dict[Path, str]:
             module = extract_stub(source, rel_path)
         except SyntaxError:
             continue
-        if not module.classes and not module.functions:
+        if not module.classes and not module.functions and not module.constants:
             continue
         result[Path(rel_path).with_suffix(".pyi")] = render_stub(module)
     return result

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -19,6 +19,12 @@ class TestIsPublic:
     def test_name_mangled(self):
         assert is_public("__foo") is False
 
+    def test_dunder_all_is_public(self):
+        assert is_public("__all__") is True
+
+    def test_dunder_version_is_public(self):
+        assert is_public("__version__") is True
+
 
 class TestExtractModule:
     def test_classes_and_functions(self):
@@ -89,6 +95,72 @@ class TestExtractModule:
 
         assert result.classes == []
         assert result.functions == []
+        assert result.constants == []
+
+    def test_module_level_constants(self):
+        source = textwrap.dedent("""\
+            TIMEOUT = 30
+            MAX_RETRIES: int = 3
+            _PRIVATE = 1
+            __version__ = "1.0.0"
+        """)
+
+        result = extract_module(source, "const.py")
+
+        assert result.constants == ["TIMEOUT", "MAX_RETRIES", "__version__"]
+
+    def test_type_alias_classic(self):
+        source = textwrap.dedent("""\
+            from typing import TypeAlias
+            UserId: TypeAlias = int
+        """)
+
+        result = extract_module(source, "aliases.py")
+
+        assert result.constants == ["UserId"]
+
+    def test_type_alias_pep695(self):
+        source = textwrap.dedent("""\
+            type UserId = int
+            type _PrivateId = int
+        """)
+
+        result = extract_module(source, "aliases.py")
+
+        assert result.constants == ["UserId"]
+
+    def test_tuple_unpacking_skipped(self):
+        source = textwrap.dedent("""\
+            X, Y = 1, 2
+        """)
+
+        result = extract_module(source, "tuple.py")
+
+        assert result.constants == []
+
+    def test_unannotated_class_variable(self):
+        source = textwrap.dedent("""\
+            class Registry:
+                items = []
+                _cache = {}
+                count: int = 0
+        """)
+
+        result = extract_module(source, "reg.py")
+
+        cls = result.classes[0]
+        assert cls.attributes == ["items", "count"]
+
+    def test_module_with_only_constants_is_kept(self, tmp_path):
+        src = tmp_path / "src"
+        pkg = src / "mypackage"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text('__version__ = "1.0"\n')
+
+        modules = walk_source(src, base=tmp_path)
+
+        rel_paths = [m.rel_path for m in modules]
+        assert "src/mypackage/__init__.py" in rel_paths
 
     def test_annotated_attributes(self):
         source = textwrap.dedent("""\

--- a/tests/test_namespace_map.py
+++ b/tests/test_namespace_map.py
@@ -115,6 +115,36 @@ class TestBuildMap:
 
         assert keys == ["Alpha", "zebra", "apple"]
 
+    def test_module_level_constants(self):
+        modules = [
+            ModuleInfo(
+                rel_path="src/pkg/settings.py",
+                constants=["TIMEOUT", "MAX_RETRIES"],
+                classes=[],
+                functions=[],
+            ),
+        ]
+
+        result = build_map(modules)
+        file_entry = result["src/"]["pkg/"]["settings.py"]
+
+        assert file_entry == {"TIMEOUT": None, "MAX_RETRIES": None}
+
+    def test_constants_precede_classes_and_functions(self):
+        modules = [
+            ModuleInfo(
+                rel_path="src/pkg/mod.py",
+                constants=["VERSION"],
+                classes=[ClassInfo(name="Foo")],
+                functions=["run"],
+            ),
+        ]
+
+        result = build_map(modules)
+        keys = list(result["src/"]["pkg/"]["mod.py"].keys())
+
+        assert keys == ["VERSION", "Foo", "run"]
+
 
 class TestRenderMap:
     def test_roundtrips_through_yaml(self):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -3,6 +3,7 @@ import textwrap
 import pytest
 
 from uncoded.stubs import (
+    StubAssignment,
     StubClass,
     StubFunction,
     StubModule,
@@ -79,10 +80,10 @@ class TestExtractStub:
         cls = module.classes[0]
         assert cls.name == "Record"
         assert cls.docstring_excerpt == "Stores a named value."
-        assert cls.attributes == [
-            StubParam("name", "str"),
-            StubParam("value", "int"),
-            StubParam("_internal", "float"),
+        assert [(a.name, a.annotation) for a in cls.attributes] == [
+            ("name", "str"),
+            ("value", "int"),
+            ("_internal", "float"),
         ]
         assert len(cls.methods) == 2
         assert cls.methods[0].name == "save"
@@ -180,6 +181,95 @@ class TestExtractStub:
         assert module.functions[1].name == "apple"
         assert module.classes[0].name == "Alpha"
 
+    def test_constant_annotated_with_value(self):
+        source = textwrap.dedent("""\
+            MAX_RETRIES: int = 3
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        c = module.constants[0]
+        assert c.name == "MAX_RETRIES"
+        assert c.annotation == "int"
+        assert c.value_source == "3"
+        assert c.is_type_alias is False
+        assert c.start_line == 1
+
+    def test_constant_unannotated_with_value(self):
+        source = textwrap.dedent("""\
+            TIMEOUT = 30
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        c = module.constants[0]
+        assert c.name == "TIMEOUT"
+        assert c.annotation is None
+        assert c.value_source == "30"
+
+    def test_constant_bare_annotation(self):
+        source = textwrap.dedent("""\
+            FOO: int
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        c = module.constants[0]
+        assert c.annotation == "int"
+        assert c.value_source is None
+
+    def test_constant_value_too_long_elided(self):
+        long_list = "[" + ", ".join(f'"item{i}"' for i in range(50)) + "]"
+        source = f"BIG = {long_list}\n"
+        module = extract_stub(source, "pkg/mod.py")
+        c = module.constants[0]
+        assert c.name == "BIG"
+        assert c.value_source == "..."
+
+    def test_constant_private_included(self):
+        source = textwrap.dedent("""\
+            _INTERNAL = 42
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        assert module.constants[0].name == "_INTERNAL"
+
+    def test_type_alias_classic(self):
+        source = textwrap.dedent("""\
+            from typing import TypeAlias
+            UserId: TypeAlias = int
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        c = module.constants[0]
+        assert c.name == "UserId"
+        assert c.annotation == "TypeAlias"
+        assert c.value_source == "int"
+        assert c.is_type_alias is False
+
+    def test_type_alias_pep695(self):
+        source = textwrap.dedent("""\
+            type UserId = int
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        c = module.constants[0]
+        assert c.name == "UserId"
+        assert c.is_type_alias is True
+        assert c.value_source == "int"
+
+    def test_tuple_unpacking_skipped(self):
+        source = textwrap.dedent("""\
+            X, Y = 1, 2
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        assert module.constants == []
+
+    def test_class_with_unannotated_attribute(self):
+        source = textwrap.dedent("""\
+            class Registry:
+                items = []
+                count: int = 0
+        """)
+        module = extract_stub(source, "pkg/mod.py")
+        cls = module.classes[0]
+        names = [(a.name, a.annotation, a.value_source) for a in cls.attributes]
+        assert names == [
+            ("items", None, "[]"),
+            ("count", "int", "0"),
+        ]
+
 
 class TestRenderStub:
     def test_header_contains_path(self):
@@ -249,6 +339,20 @@ class TestRenderStub:
         )
         assert "class Dog(Animal):  # L1-5" in render_stub(module)
 
+    def test_class_single_line_range(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            classes=[StubClass(name="Marker", start_line=7, end_line=7)],
+        )
+        assert "class Marker:  # L7\n" in render_stub(module)
+
+    def test_function_single_line_range(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            functions=[StubFunction(name="noop", start_line=3, end_line=3)],
+        )
+        assert "def noop():  # L3\n" in render_stub(module)
+
     def test_class_no_bases(self):
         module = StubModule(
             rel_path="pkg/mod.py",
@@ -264,7 +368,7 @@ class TestRenderStub:
                     name="Record",
                     start_line=1,
                     end_line=3,
-                    attributes=[StubParam("name", "str")],
+                    attributes=[StubAssignment("name", annotation="str")],
                 )
             ],
         )
@@ -295,3 +399,83 @@ class TestRenderStub:
     def test_ends_with_newline(self):
         module = StubModule(rel_path="pkg/mod.py")
         assert render_stub(module).endswith("\n")
+
+    def test_constant_with_value_rendered(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            constants=[
+                StubAssignment(
+                    name="TIMEOUT", value_source="30", start_line=3, end_line=3
+                )
+            ],
+        )
+        assert "TIMEOUT = 30  # L3" in render_stub(module)
+
+    def test_constant_annotated_with_value_rendered(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            constants=[
+                StubAssignment(
+                    name="MAX",
+                    annotation="int",
+                    value_source="3",
+                    start_line=4,
+                    end_line=4,
+                )
+            ],
+        )
+        assert "MAX: int = 3  # L4" in render_stub(module)
+
+    def test_constant_elided_rendered(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            constants=[
+                StubAssignment(
+                    name="BIG", value_source="...", start_line=5, end_line=10
+                )
+            ],
+        )
+        assert "BIG = ...  # L5-10" in render_stub(module)
+
+    def test_constant_bare_annotation_rendered(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            constants=[
+                StubAssignment(name="FOO", annotation="int", start_line=2, end_line=2)
+            ],
+        )
+        output = render_stub(module)
+        assert "FOO: int  # L2" in output
+        assert "FOO: int = " not in output
+
+    def test_type_alias_pep695_rendered(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            constants=[
+                StubAssignment(
+                    name="UserId",
+                    value_source="int",
+                    is_type_alias=True,
+                    start_line=1,
+                    end_line=1,
+                )
+            ],
+        )
+        assert "type UserId = int  # L1" in render_stub(module)
+
+    def test_unannotated_class_attribute_rendered(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            classes=[
+                StubClass(
+                    name="Registry",
+                    start_line=1,
+                    end_line=3,
+                    attributes=[StubAssignment("items", value_source="[]")],
+                )
+            ],
+        )
+        output = render_stub(module)
+        assert "    items = []" in output
+        # No line range comment on class attributes.
+        assert "items = []  # L" not in output


### PR DESCRIPTION
Closes #6.

## Summary

### Indexing (the original scope of #6)

- Namespace map and stubs now capture module-level constants (annotated + unannotated), classic type aliases (`X: TypeAlias = ...`), PEP 695 type aliases (`type X = ...`), and unannotated class-level assignments.
- `__all__` and `__version__` are treated as public dunders so package-level API remains visible.
- Stub rendering of an assignment's RHS uses `ast.unparse` with an 80-char width cap: fits → verbatim; too long or multi-line → `= ...` and the line range points at the source. The design goal is information density for an agent reader, rather than a typed `.pyi` for `mypy`.
- Line-range comments now use `# L<n>` for single-line definitions and `# L<start>-<end>` otherwise — applied uniformly across constants, functions, methods, and classes.
- Side effect: dataclass field defaults (e.g. `start_line: int = 0`) now appear in stubs because the same rendering path handles class attributes.

### Navigation section rewrite (opportunistic)

While working on this, I noticed the auto-generated CLAUDE.md navigation section had soft edges — easy for an agent to follow ritualistically without actually orienting on the code. I caught myself doing it: reading the namespace map early (while another tool was blocked), then drifting into design conversation without re-orienting, and later reading whole source files instead of using stub line ranges. Tightened the section in place:

- **Step 1** is now a session-start gate (`your first action in this session, before anything else`) rather than the ambiguous `at the start of every task`.
- **Step 2** now names a concrete operation-level precondition: *before reading any `.py` source file, read its `.pyi` stub first.* Handles the stub-less file case.
- **Step 3** is now a tool-level ban: *calling `Read` on a `.py` file without `offset` and `limit` is a protocol violation.*
- **Section title** changed from `uncoded navigation index` to `How to navigate this codebase and read source files` — instructive voice, names both concerns.

Across the three steps: session-level gate → operation-level gate → tool-level ban. Each with a named failure mode. Each observable in the transcript.

## Test plan

- [x] `pytest` — 95 tests pass, including new coverage for constants, type aliases (classic + PEP 695), unannotated class vars, dunder exceptions, the width-cap elision, and the `L<n>` vs `L<n>-<m>` rendering.
- [x] `pre-commit run --all-files` — clean (ruff, ruff-format, ty, uncoded).
- [x] Regenerated `.uncoded/namespace.yaml` and stubs on this repo to verify real-world output (e.g. `_SECTION_BODY = ...  # L10-41`, `VALUE_WIDTH_CAP = 80  # L12`).
- [x] Regenerated CLAUDE.md navigation section and re-read it fresh to verify the new wording makes sense end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)