### PR TITLE
Render @property as class attribute, not method

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -111,6 +111,8 @@ tests/:
       test_module_with_only_constants_is_kept:
       test_annotated_attributes:
       test_class_with_no_public_members:
+      test_property_classified_as_attribute:
+      test_property_setter_and_deleter_suppressed:
       test_preserves_source_order:
     TestWalkSource:
       test_basic_walk:
@@ -159,6 +161,9 @@ tests/:
       test_type_alias_pep695:
       test_tuple_unpacking_skipped:
       test_class_with_unannotated_attribute:
+      test_property_rendered_as_attribute:
+      test_property_without_return_annotation:
+      test_property_setter_and_deleter_suppressed:
     TestRenderStub:
       test_header_contains_path:
       test_imports_rendered:
@@ -173,6 +178,7 @@ tests/:
       test_attribute_with_annotation:
       test_method_indented:
       test_ends_with_newline:
+      test_property_rendered_as_class_attribute:
       test_constant_with_value_rendered:
       test_constant_annotated_with_value_rendered:
       test_constant_elided_rendered:

--- a/.uncoded/stubs/src/uncoded/extract.pyi
+++ b/.uncoded/stubs/src/uncoded/extract.pyi
@@ -11,19 +11,23 @@ def is_public(name: str) -> bool:  # L32-36
     """A name is public if it has no leading underscore (or is a public dunder)."""
     ...
 
-def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:  # L39-47
+def _property_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:  # L39-52
+    """Classify a method by its property-related decorators."""
+    ...
+
+def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:  # L55-63
     """Return the single-name target of an assignment, or None if not a simple name."""
     ...
 
-def extract_module(source: str, rel_path: str) -> ModuleInfo:  # L50-93
+def extract_module(source: str, rel_path: str) -> ModuleInfo:  # L66-113
     """Parse Python source and extract public classes, functions, and constants."""
     ...
 
-def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[str, str]]:  # L96-123
+def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[str, str]]:  # L116-143
     """Yield (source_text, rel_path) for each candidate Python file."""
     ...
 
-def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:  # L126-147
+def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:  # L146-167
     """Walk a source root and extract public symbols from all packages."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -4,10 +4,10 @@ import ast
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from uncoded.extract import iter_source_files
+from uncoded.extract import _property_kind, iter_source_files
 
 VALUE_WIDTH_CAP = 80  # L12
-DEFAULT_STUBS_OUTPUT = Path('.uncoded/stubs')  # L350
+DEFAULT_STUBS_OUTPUT = Path('.uncoded/stubs')  # L370
 
 def _first_sentence(node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module) -> str | None:  # L77-88
     """Return the first sentence of a node's docstring, or None."""
@@ -33,43 +33,47 @@ def _extract_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubFunct
     """Build a StubFunction from a function or method AST node."""
     ...
 
-def _extract_class(node: ast.ClassDef) -> StubClass:  # L200-223
+def _property_attribute(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubAssignment:  # L200-211
+    """Build a StubAssignment representing a @property as a class attribute."""
+    ...
+
+def _extract_class(node: ast.ClassDef) -> StubClass:  # L214-243
     """Build a StubClass from a class AST node."""
     ...
 
-def extract_stub(source: str, rel_path: str) -> StubModule:  # L226-252
+def extract_stub(source: str, rel_path: str) -> StubModule:  # L246-272
     """Parse Python source and extract all symbols with signatures and line ranges."""
     ...
 
-def _render_param(p: StubParam) -> str:  # L255-261
+def _render_param(p: StubParam) -> str:  # L275-281
     """Render a single parameter as a string for a function signature."""
     ...
 
-def _render_function(func: StubFunction, indent: str) -> list[str]:  # L264-275
+def _render_function(func: StubFunction, indent: str) -> list[str]:  # L284-295
     """Render a function or method as stub lines, indented for methods."""
     ...
 
-def _format_assignment_body(a: StubAssignment) -> str:  # L278-285
+def _format_assignment_body(a: StubAssignment) -> str:  # L298-305
     """Render the 'name [: type] [= value]' portion of an assignment."""
     ...
 
-def _render_assignment(a: StubAssignment, indent: str) -> str:  # L288-291
+def _render_assignment(a: StubAssignment, indent: str) -> str:  # L308-311
     """Render a module-level assignment as a stub line, with line range."""
     ...
 
-def _render_class_attribute(a: StubAssignment, indent: str) -> str:  # L294-296
+def _render_class_attribute(a: StubAssignment, indent: str) -> str:  # L314-316
     """Render a class attribute as a stub line (no line range — class has one)."""
     ...
 
-def render_stub(module: StubModule) -> str:  # L299-333
+def render_stub(module: StubModule) -> str:  # L319-353
     """Render a StubModule as a .pyi file string."""
     ...
 
-def _generate_stubs(source_root: Path) -> dict[Path, str]:  # L336-347
+def _generate_stubs(source_root: Path) -> dict[Path, str]:  # L356-367
     """Return a mapping from stub relative paths to rendered stub content."""
     ...
 
-def build_stubs(source_root: Path, output_dir: Path) -> None:  # L353-359
+def build_stubs(source_root: Path, output_dir: Path) -> None:  # L373-379
     """Write stub files for all symbols under source_root."""
     ...
 

--- a/.uncoded/stubs/tests/test_extract.pyi
+++ b/.uncoded/stubs/tests/test_extract.pyi
@@ -26,7 +26,7 @@ class TestIsPublic:  # L6-26
     def test_dunder_version_is_public(self):  # L25-26
         ...
 
-class TestExtractModule:  # L29-224
+class TestExtractModule:  # L29-263
 
     def test_classes_and_functions(self):  # L30-56
         ...
@@ -64,25 +64,31 @@ class TestExtractModule:  # L29-224
     def test_class_with_no_public_members(self):  # L186-203
         ...
 
-    def test_preserves_source_order(self):  # L205-224
+    def test_property_classified_as_attribute(self):  # L205-220
         ...
 
-class TestWalkSource:  # L227-318
-
-    def test_basic_walk(self, tmp_path):  # L228-253
+    def test_property_setter_and_deleter_suppressed(self):  # L222-242
         ...
 
-    def test_nested_subpackage(self, tmp_path):  # L255-267
+    def test_preserves_source_order(self):  # L244-263
         ...
 
-    def test_skips_private_subdirectory(self, tmp_path):  # L269-279
+class TestWalkSource:  # L266-357
+
+    def test_basic_walk(self, tmp_path):  # L267-292
         ...
 
-    def test_includes_init_with_public_symbols(self, tmp_path):  # L281-292
+    def test_nested_subpackage(self, tmp_path):  # L294-306
         ...
 
-    def test_skips_empty_init(self, tmp_path):  # L294-304
+    def test_skips_private_subdirectory(self, tmp_path):  # L308-318
         ...
 
-    def test_skips_syntax_errors(self, tmp_path):  # L306-318
+    def test_includes_init_with_public_symbols(self, tmp_path):  # L320-331
+        ...
+
+    def test_skips_empty_init(self, tmp_path):  # L333-343
+        ...
+
+    def test_skips_syntax_errors(self, tmp_path):  # L345-357
         ...

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -4,7 +4,7 @@ import textwrap
 import pytest
 from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, extract_stub, render_stub
 
-class TestExtractStub:  # L16-321
+class TestExtractStub:  # L16-320
 
     def test_simple_function(self):  # L17-31
         ...
@@ -75,73 +75,73 @@ class TestExtractStub:  # L16-321
     def test_class_with_unannotated_attribute(self):  # L259-271
         ...
 
-    def test_property_rendered_as_attribute(self):  # L274-289
+    def test_property_rendered_as_attribute(self):  # L273-288
         ...
 
-    def test_property_without_return_annotation(self):  # L291-301
+    def test_property_without_return_annotation(self):  # L290-300
         ...
 
-    def test_property_setter_and_deleter_suppressed(self):  # L303-321
+    def test_property_setter_and_deleter_suppressed(self):  # L302-320
         ...
 
-class TestRenderStub:  # L324-547
+class TestRenderStub:  # L323-546
 
-    def test_header_contains_path(self):  # L325-327
+    def test_header_contains_path(self):  # L324-326
         ...
 
-    def test_imports_rendered(self):  # L329-335
+    def test_imports_rendered(self):  # L328-334
         ...
 
-    def test_function_line_range(self):  # L337-343
+    def test_function_line_range(self):  # L336-342
         ...
 
-    def test_async_function_prefix(self):  # L345-352
+    def test_async_function_prefix(self):  # L344-351
         ...
 
-    def test_function_with_annotations(self):  # L354-367
+    def test_function_with_annotations(self):  # L353-366
         ...
 
-    def test_docstring_excerpt_rendered(self):  # L369-383
+    def test_docstring_excerpt_rendered(self):  # L368-382
         ...
 
-    def test_class_with_bases(self):  # L385-390
+    def test_class_with_bases(self):  # L384-389
         ...
 
-    def test_class_single_line_range(self):  # L392-397
+    def test_class_single_line_range(self):  # L391-396
         ...
 
-    def test_function_single_line_range(self):  # L399-404
+    def test_function_single_line_range(self):  # L398-403
         ...
 
-    def test_class_no_bases(self):  # L406-411
+    def test_class_no_bases(self):  # L405-410
         ...
 
-    def test_attribute_with_annotation(self):  # L413-425
+    def test_attribute_with_annotation(self):  # L412-424
         ...
 
-    def test_method_indented(self):  # L427-447
+    def test_method_indented(self):  # L426-446
         ...
 
-    def test_ends_with_newline(self):  # L449-451
+    def test_ends_with_newline(self):  # L448-450
         ...
 
-    def test_property_rendered_as_class_attribute(self):  # L453-467
+    def test_property_rendered_as_class_attribute(self):  # L452-466
         ...
 
-    def test_constant_with_value_rendered(self):  # L469-478
+    def test_constant_with_value_rendered(self):  # L468-477
         ...
 
-    def test_constant_annotated_with_value_rendered(self):  # L480-493
+    def test_constant_annotated_with_value_rendered(self):  # L479-492
         ...
 
-    def test_constant_elided_rendered(self):  # L495-504
+    def test_constant_elided_rendered(self):  # L494-503
         ...
 
-    def test_constant_bare_annotation_rendered(self):  # L506-515
+    def test_constant_bare_annotation_rendered(self):  # L505-514
         ...
 
-    def test_type_alias_pep695_rendered(self):  # L517-530
+    def test_type_alias_pep695_rendered(self):  # L516-529
         ...
 
-    def test_unannotated_class_attribute_rendered(self):  # L532-547
+    def test_unannotated_class_attribute_rendered(self):  # L531-546
         ...

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -4,7 +4,7 @@ import textwrap
 import pytest
 from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, extract_stub, render_stub
 
-class TestExtractStub:  # L16-271
+class TestExtractStub:  # L16-321
 
     def test_simple_function(self):  # L17-31
         ...
@@ -75,61 +75,73 @@ class TestExtractStub:  # L16-271
     def test_class_with_unannotated_attribute(self):  # L259-271
         ...
 
-class TestRenderStub:  # L274-481
-
-    def test_header_contains_path(self):  # L275-277
+    def test_property_rendered_as_attribute(self):  # L274-289
         ...
 
-    def test_imports_rendered(self):  # L279-285
+    def test_property_without_return_annotation(self):  # L291-301
         ...
 
-    def test_function_line_range(self):  # L287-293
+    def test_property_setter_and_deleter_suppressed(self):  # L303-321
         ...
 
-    def test_async_function_prefix(self):  # L295-302
+class TestRenderStub:  # L324-547
+
+    def test_header_contains_path(self):  # L325-327
         ...
 
-    def test_function_with_annotations(self):  # L304-317
+    def test_imports_rendered(self):  # L329-335
         ...
 
-    def test_docstring_excerpt_rendered(self):  # L319-333
+    def test_function_line_range(self):  # L337-343
         ...
 
-    def test_class_with_bases(self):  # L335-340
+    def test_async_function_prefix(self):  # L345-352
         ...
 
-    def test_class_single_line_range(self):  # L342-347
+    def test_function_with_annotations(self):  # L354-367
         ...
 
-    def test_function_single_line_range(self):  # L349-354
+    def test_docstring_excerpt_rendered(self):  # L369-383
         ...
 
-    def test_class_no_bases(self):  # L356-361
+    def test_class_with_bases(self):  # L385-390
         ...
 
-    def test_attribute_with_annotation(self):  # L363-375
+    def test_class_single_line_range(self):  # L392-397
         ...
 
-    def test_method_indented(self):  # L377-397
+    def test_function_single_line_range(self):  # L399-404
         ...
 
-    def test_ends_with_newline(self):  # L399-401
+    def test_class_no_bases(self):  # L406-411
         ...
 
-    def test_constant_with_value_rendered(self):  # L403-412
+    def test_attribute_with_annotation(self):  # L413-425
         ...
 
-    def test_constant_annotated_with_value_rendered(self):  # L414-427
+    def test_method_indented(self):  # L427-447
         ...
 
-    def test_constant_elided_rendered(self):  # L429-438
+    def test_ends_with_newline(self):  # L449-451
         ...
 
-    def test_constant_bare_annotation_rendered(self):  # L440-449
+    def test_property_rendered_as_class_attribute(self):  # L453-467
         ...
 
-    def test_type_alias_pep695_rendered(self):  # L451-464
+    def test_constant_with_value_rendered(self):  # L469-478
         ...
 
-    def test_unannotated_class_attribute_rendered(self):  # L466-481
+    def test_constant_annotated_with_value_rendered(self):  # L480-493
+        ...
+
+    def test_constant_elided_rendered(self):  # L495-504
+        ...
+
+    def test_constant_bare_annotation_rendered(self):  # L506-515
+        ...
+
+    def test_type_alias_pep695_rendered(self):  # L517-530
+        ...
+
+    def test_unannotated_class_attribute_rendered(self):  # L532-547
         ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,16 @@ Two-level index:
 
 ## Commands
 
+This project uses [uv](https://docs.astral.sh/uv/). Run commands via
+`uv run` so they execute inside the project environment without needing
+an activated venv.
+
 ```
 # Generate (or update) the namespace map, stub files, and CLAUDE.md section
-uncoded
+uv run uncoded
 
 # Run tests
-pytest
+uv run pytest
 ```
 
 <!-- uncoded:start -->

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -36,6 +36,22 @@ def is_public(name: str) -> bool:
     return not name.startswith("_")
 
 
+def _property_kind(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> str | None:
+    """Classify a method by its property-related decorators.
+
+    Returns "property" for @property, "setter" for @<name>.setter,
+    "deleter" for @<name>.deleter, or None for a plain method.
+    """
+    for d in node.decorator_list:
+        if isinstance(d, ast.Name) and d.id == "property":
+            return "property"
+        if isinstance(d, ast.Attribute) and d.attr in ("setter", "deleter"):
+            return d.attr
+    return None
+
+
 def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:
     """Return the single-name target of an assignment, or None if not a simple name."""
     if isinstance(node, ast.AnnAssign):
@@ -58,18 +74,22 @@ def extract_module(source: str, rel_path: str) -> ModuleInfo:
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.ClassDef) and is_public(node.name):
             attributes: list[str] = []
+            methods: list[str] = []
             for n in ast.iter_child_nodes(node):
-                name = None
                 if isinstance(n, (ast.AnnAssign, ast.Assign)):
                     name = _assign_target_name(n)
-                if name and is_public(name):
-                    attributes.append(name)
-            methods = [
-                n.name
-                for n in ast.iter_child_nodes(node)
-                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
-                and is_public(n.name)
-            ]
+                    if name and is_public(name):
+                        attributes.append(name)
+                elif isinstance(
+                    n, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ) and is_public(n.name):
+                    kind = _property_kind(n)
+                    if kind == "setter" or kind == "deleter":
+                        continue
+                    if kind == "property":
+                        attributes.append(n.name)
+                    else:
+                        methods.append(n.name)
             classes.append(
                 ClassInfo(name=node.name, attributes=attributes, methods=methods)
             )

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from uncoded.extract import iter_source_files
+from uncoded.extract import _property_kind, iter_source_files
 
 # Width cap for inlining the right-hand side of an assignment. If the unparsed
 # RHS exceeds this, it is elided to "..." and the reader follows the line range.
@@ -197,6 +197,20 @@ def _extract_function(
     )
 
 
+def _property_attribute(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> StubAssignment:
+    """Build a StubAssignment representing a @property as a class attribute."""
+    return StubAssignment(
+        name=node.name,
+        annotation=ast.unparse(node.returns) if node.returns else None,
+        value_source=None,
+        start_line=node.lineno,
+        end_line=node.end_lineno or node.lineno,
+        is_type_alias=False,
+    )
+
+
 def _extract_class(node: ast.ClassDef) -> StubClass:
     """Build a StubClass from a class AST node."""
     bases = [ast.unparse(b) for b in node.bases]
@@ -210,7 +224,13 @@ def _extract_class(node: ast.ClassDef) -> StubClass:
             if assignment is not None:
                 attributes.append(assignment)
         elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            methods.append(_extract_function(child))
+            kind = _property_kind(child)
+            if kind == "setter" or kind == "deleter":
+                continue
+            if kind == "property":
+                attributes.append(_property_attribute(child))
+            else:
+                methods.append(_extract_function(child))
 
     return StubClass(
         name=node.name,

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -202,6 +202,45 @@ class TestExtractModule:
         assert result.classes[0].attributes == []
         assert result.classes[0].methods == []
 
+    def test_property_classified_as_attribute(self):
+        source = textwrap.dedent("""\
+            class Config:
+                @property
+                def path(self):
+                    return self._path
+
+                def save(self):
+                    pass
+        """)
+
+        result = extract_module(source, "config.py")
+
+        cls = result.classes[0]
+        assert cls.attributes == ["path"]
+        assert cls.methods == ["save"]
+
+    def test_property_setter_and_deleter_suppressed(self):
+        source = textwrap.dedent("""\
+            class Config:
+                @property
+                def path(self):
+                    return self._path
+
+                @path.setter
+                def path(self, value):
+                    self._path = value
+
+                @path.deleter
+                def path(self):
+                    del self._path
+        """)
+
+        result = extract_module(source, "config.py")
+
+        cls = result.classes[0]
+        assert cls.attributes == ["path"]
+        assert cls.methods == []
+
     def test_preserves_source_order(self):
         source = textwrap.dedent("""\
             def zebra():

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -270,7 +270,6 @@ class TestExtractStub:
             ("count", "int", "0"),
         ]
 
-
     def test_property_rendered_as_attribute(self):
         source = textwrap.dedent("""\
             class Config:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -271,6 +271,56 @@ class TestExtractStub:
         ]
 
 
+    def test_property_rendered_as_attribute(self):
+        source = textwrap.dedent("""\
+            class Config:
+                @property
+                def path(self) -> Path:
+                    '''Return the config file path.'''
+                    return self._path
+        """)
+        module = extract_stub(source, "pkg/cfg.py")
+        cls = module.classes[0]
+        assert cls.methods == []
+        assert len(cls.attributes) == 1
+        attr = cls.attributes[0]
+        assert attr.name == "path"
+        assert attr.annotation == "Path"
+        assert attr.value_source is None
+
+    def test_property_without_return_annotation(self):
+        source = textwrap.dedent("""\
+            class Config:
+                @property
+                def path(self):
+                    return self._path
+        """)
+        module = extract_stub(source, "pkg/cfg.py")
+        cls = module.classes[0]
+        assert cls.attributes[0].name == "path"
+        assert cls.attributes[0].annotation is None
+
+    def test_property_setter_and_deleter_suppressed(self):
+        source = textwrap.dedent("""\
+            class Config:
+                @property
+                def path(self) -> Path:
+                    return self._path
+
+                @path.setter
+                def path(self, value: Path) -> None:
+                    self._path = value
+
+                @path.deleter
+                def path(self) -> None:
+                    del self._path
+        """)
+        module = extract_stub(source, "pkg/cfg.py")
+        cls = module.classes[0]
+        assert [a.name for a in cls.attributes] == ["path"]
+        assert cls.methods == []
+
+
 class TestRenderStub:
     def test_header_contains_path(self):
         module = StubModule(rel_path="src/pkg/mod.py")
@@ -399,6 +449,22 @@ class TestRenderStub:
     def test_ends_with_newline(self):
         module = StubModule(rel_path="pkg/mod.py")
         assert render_stub(module).endswith("\n")
+
+    def test_property_rendered_as_class_attribute(self):
+        source = textwrap.dedent("""\
+            class Config:
+                @property
+                def path(self) -> Path:
+                    return self._path
+
+                @path.setter
+                def path(self, value: Path) -> None:
+                    self._path = value
+        """)
+        module = extract_stub(source, "pkg/cfg.py")
+        output = render_stub(module)
+        assert "    path: Path" in output
+        assert "def path" not in output
 
     def test_constant_with_value_rendered(self):
         module = StubModule(


### PR DESCRIPTION
Closes #7.

## Summary
- `@property` methods now render as `name: <return-type>` in both the namespace map and the `.pyi` stubs, instead of as `def name(self) -> type`.
- `@<name>.setter` and `@<name>.deleter` are suppressed — the attribute form covers read/write intent.
- First-sentence docstrings are dropped on properties, matching the treatment of other class attributes. The class's line range is sufficient to locate the property in source.

## Before / after

Given:

```python
class Config:
    @property
    def path(self) -> Path:
        """Return the config file path."""
        return self._path
```

Before:

```python
class Config:  # L1-4
    def path(self) -> Path:  # L2-4
        """Return the config file path."""
        ...
```

After:

```python
class Config:  # L1-4
    path: Path
```

## Test plan
- [x] New extract tests: property classified as attribute; setter and deleter suppressed
- [x] New stub tests: property extracted with return-type annotation; missing return annotation handled; setter/deleter suppressed; end-to-end render produces `path: Path` with no `def path`
- [x] `pytest` — 101 passing
- [x] `uncoded` — namespace map and stubs regenerated, diff is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)