### PR TITLE
Expand Serena guidance into a full symbol-operations section

### DIFF
--- a/.uncoded/stubs/src/uncoded/instruction_files.pyi
+++ b/.uncoded/stubs/src/uncoded/instruction_files.pyi
@@ -6,17 +6,17 @@ from uncoded.sync import sync_file
 MARKER_START = '<!-- uncoded:start -->'  # L14
 MARKER_END = '<!-- uncoded:end -->'  # L15
 DEFAULT_INSTRUCTION_FILES = [Path('CLAUDE.md'), Path('AGENTS.md')]  # L17
-_SECTION_BODY = ...  # L19-74
-SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L76
+_SECTION_BODY = ...  # L19-99
+SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L101
 
-def generate_section() -> str:  # L79-81
+def generate_section() -> str:  # L104-106
     """Return the full delimited uncoded section for an instruction file."""
     ...
 
-def _replace_or_append(existing: str, section: str) -> str:  # L84-94
+def _replace_or_append(existing: str, section: str) -> str:  # L109-119
     """Replace the delimited section in existing text, or append it if absent."""
     ...
 
-def sync_instruction_file(path: Path, *, check: bool) -> bool:  # L97-108
+def sync_instruction_file(path: Path, *, check: bool) -> bool:  # L122-133
     """Write or update the uncoded navigation section in an instruction file."""
     ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,35 @@ of the file than the stub said you needed. The one exception is the
 first Read of a stub-less file (see Step 2), which is genuinely
 exploratory.
 
-**For cross-file operations** — find references, rename, check whether a
-symbol is still used — prefer a language-server MCP bridge like Serena
-(`find_symbol`, `find_referencing_symbols`, `rename_symbol`) over grep,
-if one is available. The namespace map gives the `name_path` (e.g.
-`ClassName/method` for a method, `function_name` for a top-level
-function) and `relative_path` these tools take as input.
+**For symbol-level operations — use Serena.** Where Serena's MCP tools
+are available (`mcp__serena__*` in the tool list), prefer them over
+Read / Edit / grep for anything that operates on a symbol as a unit.
+The namespace map gives you the exact `name_path` and `relative_path`
+these tools take as input — e.g. `ClassName/method` for a method,
+`function_name` for a top-level function.
+
+- **Read one symbol body.** `find_symbol` with `include_body=True`
+  returns exactly the symbol — no `offset` / `limit` arithmetic, no
+  risk of reading too much. Often easier than the Step 3 dance for a
+  single function or method. (Stay on stubs for a wider sweep.)
+- **Find callers, or check whether a symbol is dead.**
+  `find_referencing_symbols` returns every reference resolved by the
+  language server. Do not grep for the name — grep hits comments,
+  strings, attribute lookups on unrelated types, and re-exports.
+- **Rename.** `rename_symbol` updates every reference across the
+  codebase in one call. Multi-file find-and-replace misses imports
+  and re-exports and racks up false positives.
+- **Edit a whole symbol.** `replace_symbol_body`,
+  `insert_before_symbol`, and `insert_after_symbol` operate on the
+  symbol as a unit. Immune to the Edit tool's "string not unique"
+  failure mode, never accidentally modify a similarly-named
+  neighbour, and keep surrounding indentation consistent.
+- **Delete a symbol.** `safe_delete_symbol` checks for live
+  references before removing — dead code goes cleanly, live code
+  stays put.
+
+Reach for Read + Edit when Serena does not fit: free-text files
+(Markdown, YAML, configs), partial-line edits inside a function
+body, or the rare stub-less Python file that needs exploratory
+reading.
 <!-- uncoded:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ uv run pytest
 ```
 
 <!-- uncoded:start -->
-## How to navigate this codebase and read source files
+## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a navigation index for AI agents. Do not grep. Do not read whole source files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,35 @@ of the file than the stub said you needed. The one exception is the
 first Read of a stub-less file (see Step 2), which is genuinely
 exploratory.
 
-**For cross-file operations** — find references, rename, check whether a
-symbol is still used — prefer a language-server MCP bridge like Serena
-(`find_symbol`, `find_referencing_symbols`, `rename_symbol`) over grep,
-if one is available. The namespace map gives the `name_path` (e.g.
-`ClassName/method` for a method, `function_name` for a top-level
-function) and `relative_path` these tools take as input.
+**For symbol-level operations — use Serena.** Where Serena's MCP tools
+are available (`mcp__serena__*` in the tool list), prefer them over
+Read / Edit / grep for anything that operates on a symbol as a unit.
+The namespace map gives you the exact `name_path` and `relative_path`
+these tools take as input — e.g. `ClassName/method` for a method,
+`function_name` for a top-level function.
+
+- **Read one symbol body.** `find_symbol` with `include_body=True`
+  returns exactly the symbol — no `offset` / `limit` arithmetic, no
+  risk of reading too much. Often easier than the Step 3 dance for a
+  single function or method. (Stay on stubs for a wider sweep.)
+- **Find callers, or check whether a symbol is dead.**
+  `find_referencing_symbols` returns every reference resolved by the
+  language server. Do not grep for the name — grep hits comments,
+  strings, attribute lookups on unrelated types, and re-exports.
+- **Rename.** `rename_symbol` updates every reference across the
+  codebase in one call. Multi-file find-and-replace misses imports
+  and re-exports and racks up false positives.
+- **Edit a whole symbol.** `replace_symbol_body`,
+  `insert_before_symbol`, and `insert_after_symbol` operate on the
+  symbol as a unit. Immune to the Edit tool's "string not unique"
+  failure mode, never accidentally modify a similarly-named
+  neighbour, and keep surrounding indentation consistent.
+- **Delete a symbol.** `safe_delete_symbol` checks for live
+  references before removing — dead code goes cleanly, live code
+  stays put.
+
+Reach for Read + Edit when Serena does not fit: free-text files
+(Markdown, YAML, configs), partial-line edits inside a function
+body, or the rare stub-less Python file that needs exploratory
+reading.
 <!-- uncoded:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ uv run pytest
 ```
 
 <!-- uncoded:start -->
-## How to navigate this codebase and read source files
+## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a navigation index for AI agents. Do not grep. Do not read whole source files.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ hallucinated understanding of code that's sitting right there, unread.
 at the start of a task and navigate deterministically to what they need —
 no guessing, no grep.
 
-Additionally, **uncoded** provides some convenience for setting up your coding agent with a language server, so they can reliably find symbol usages and rename or delete symbols safely.
+Additionally, **uncoded** provides some convenience for setting up your coding agent with a language server, so they can reliably find symbol usages and rename, edit, or delete symbols safely.
 
 ## What it generates
 
@@ -108,9 +108,10 @@ Three reads to navigate to any symbol in the codebase. No grep.
 
 ## Using uncoded with a language server
 
-Cross-file operations — find references, rename, check whether a symbol is
-still used — are better served by a language server than by grep. Uncoded's
-map supplies the `name_path` and `relative_path` these tools take as input.
+Symbol-level operations — finding callers, reading or editing a single
+symbol, renaming, safe deletion — are better served by a language server
+than by grep and freeform text edits. Uncoded's map supplies the
+`name_path` and `relative_path` these tools take as input.
 
 The recommended setup is [oraios/serena][serena] as the MCP bridge with
 [astral-sh/ty][ty] as the Python language-server backend. Serena launches
@@ -129,7 +130,7 @@ Generates three files, tailored for Claude Code:
 - **`.serena/project.yml`** — picks ty as the backend, ignores `.uncoded/`,
   drops the redundant `execute_shell_command`.
 - **`.claude/settings.json`** — enables the Serena server and allowlists
-  its navigation, rename, and memory tools.
+  its navigation, edit, and memory tools.
 
 Safe to re-run: JSON files merge into existing content (so pre-existing
 MCP servers and permissions are preserved), and the Serena project YAML

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -66,12 +66,37 @@ of the file than the stub said you needed. The one exception is the
 first Read of a stub-less file (see Step 2), which is genuinely
 exploratory.
 
-**For cross-file operations** — find references, rename, check whether a
-symbol is still used — prefer a language-server MCP bridge like Serena
-(`find_symbol`, `find_referencing_symbols`, `rename_symbol`) over grep,
-if one is available. The namespace map gives the `name_path` (e.g.
-`ClassName/method` for a method, `function_name` for a top-level
-function) and `relative_path` these tools take as input."""
+**For symbol-level operations — use Serena.** Where Serena's MCP tools
+are available (`mcp__serena__*` in the tool list), prefer them over
+Read / Edit / grep for anything that operates on a symbol as a unit.
+The namespace map gives you the exact `name_path` and `relative_path`
+these tools take as input — e.g. `ClassName/method` for a method,
+`function_name` for a top-level function.
+
+- **Read one symbol body.** `find_symbol` with `include_body=True`
+  returns exactly the symbol — no `offset` / `limit` arithmetic, no
+  risk of reading too much. Often easier than the Step 3 dance for a
+  single function or method. (Stay on stubs for a wider sweep.)
+- **Find callers, or check whether a symbol is dead.**
+  `find_referencing_symbols` returns every reference resolved by the
+  language server. Do not grep for the name — grep hits comments,
+  strings, attribute lookups on unrelated types, and re-exports.
+- **Rename.** `rename_symbol` updates every reference across the
+  codebase in one call. Multi-file find-and-replace misses imports
+  and re-exports and racks up false positives.
+- **Edit a whole symbol.** `replace_symbol_body`,
+  `insert_before_symbol`, and `insert_after_symbol` operate on the
+  symbol as a unit. Immune to the Edit tool's "string not unique"
+  failure mode, never accidentally modify a similarly-named
+  neighbour, and keep surrounding indentation consistent.
+- **Delete a symbol.** `safe_delete_symbol` checks for live
+  references before removing — dead code goes cleanly, live code
+  stays put.
+
+Reach for Read + Edit when Serena does not fit: free-text files
+(Markdown, YAML, configs), partial-line edits inside a function
+body, or the rare stub-less Python file that needs exploratory
+reading."""
 
 SECTION = f"{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n"
 

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -17,7 +17,7 @@ MARKER_END = "<!-- uncoded:end -->"
 DEFAULT_INSTRUCTION_FILES = [Path("CLAUDE.md"), Path("AGENTS.md")]
 
 _SECTION_BODY = """\
-## How to navigate this codebase and read source files
+## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a navigation index for AI agents. Do not grep. Do not read whole source files.


### PR DESCRIPTION
## Summary

The closing Serena paragraph in the generated agent-instruction section
previously named only three tools (`find_symbol`,
`find_referencing_symbols`, `rename_symbol`) for "cross-file operations".
Compared to the actual allowlist in `serena_setup.py`, this dramatically
under-sells what's available — it leaves out `replace_symbol_body`,
`insert_before_symbol`, `insert_after_symbol`, `safe_delete_symbol`, and
`find_symbol(include_body=True)` for reading single bodies without
`offset`/`limit` arithmetic.

This PR promotes the paragraph into a proper closing section organised by
what the agent is trying to do:

- read one symbol body
- find callers / detect dead code
- rename
- edit a whole symbol
- delete a symbol

Each bullet pairs the tool with a specific reason to prefer it over the
Read/Edit/grep alternative — e.g. why grep is wrong for finding callers
(comments, strings, attribute lookups, re-exports), why
`replace_symbol_body` sidesteps the Edit tool's "string not unique"
failure mode. The section closes with a clear bookend on when Read +
Edit is still the right choice (free-text files, partial-line edits,
stub-less Python).

The change lives in `_SECTION_BODY` in `src/uncoded/instruction_files.py`;
`uv run uncoded sync` regenerated `CLAUDE.md`, `AGENTS.md`, and the stub.
No tests pin the wording of the section; only the markers and idempotence
behaviours are tested, all of which still pass.

## Test plan

- [x] `uv run pytest` (161 passed)
- [x] `uv run uncoded check` (clean)
- [x] Pre-commit hooks (ruff, ty, uncoded) all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)