### PR TITLE
Make PR-as-unit-of-coherence explicit in SYSTEM.md

### DIFF
--- a/SYSTEM.md
+++ b/SYSTEM.md
@@ -42,6 +42,8 @@ Remember: this is your project, your code base, your call.
 
 Bring changes in via pull requests. When finished a piece of work, open a PR.
 
+Each PR must leave the codebase coherent. The PR is the unit of coherence — not the session, not the next planned PR. If a change makes anything else stale, inconsistent, or misleading and you can name what, fixing it belongs in this PR, not a follow-up. The test: if this PR merged and the planned follow-up never happened, would the codebase be coherent? If not, fold the follow-up in. "Smaller PR" is not a reason to split — a smaller PR that ships an incoherent intermediate state is worse than a larger one that ships a clean step.
+
 Get a third-party review on pull requests. Don’t self-merge without a review.
 
 ## Autonomy


### PR DESCRIPTION
## Summary

In the previous session I correctly identified that merging the
`expand-serena-guidance` PR before updating the README would leave the
docs disagreeing with each other — and chose to merge anyway, deferring
the README to a follow-up. The reviewer had to override and ask for the
README to be folded in. The existing contract already said "expand the
scope of work to maintain coherence" and "reconcile here and now" but I
treated those as session-scoped preferences, not PR-scoped requirements.

This PR adds one paragraph to `## Change management` that crystallises
the rule:

- **Each PR must leave the codebase coherent.** The PR is the unit of
  coherence — not the session, not the next planned PR.
- **Operational test:** if this PR merged and the planned follow-up
  never happened, would the codebase be coherent? If not, fold the
  follow-up in.
- **"Smaller PR" purity is not a reason to split** when splitting ships
  an incoherent intermediate state.

Scope is deliberately bounded to *named* inconsistencies the current
change introduces ("if you can name what"), so the rule catches the
failure mode without inviting sprawling tangentially-related cleanups.

Placement under `## Change management` (rather than `## You are the code
maintainer`) anchors the principle to the PR boundary, where it bites.

## Test plan

- [x] Pre-commit hooks pass
- [ ] Reviewer sanity-check on wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)