### PR TITLE
Narrow Serena surface to pure LSP tools (#24)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,23 +4,14 @@
   ],
   "permissions": {
     "allow": [
-      "mcp__serena__check_onboarding_performed",
-      "mcp__serena__find_referencing_symbols",
       "mcp__serena__find_symbol",
+      "mcp__serena__find_referencing_symbols",
       "mcp__serena__get_symbols_overview",
-      "mcp__serena__initial_instructions",
-      "mcp__serena__list_memories",
-      "mcp__serena__read_memory",
       "mcp__serena__rename_symbol",
-      "mcp__serena__insert_after_symbol",
-      "mcp__serena__insert_before_symbol",
-      "mcp__serena__replace_symbol_body",
       "mcp__serena__safe_delete_symbol",
-      "mcp__serena__write_memory",
-      "mcp__serena__edit_memory",
-      "mcp__serena__delete_memory",
-      "mcp__serena__rename_memory",
-      "mcp__serena__onboarding"
+      "mcp__serena__insert_before_symbol",
+      "mcp__serena__insert_after_symbol",
+      "mcp__serena__replace_symbol_body"
     ]
   }
 }

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,156 +1,16 @@
-# the name by which the project can be referenced within Serena
 project_name: "uncoded"
-
-
-# list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   haxe                java                julia               kotlin              lua
-#   markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
-# Note:
-#   - For C, use cpp
-#   - For JavaScript, use typescript
-#   - For Free Pascal/Lazarus, use pascal
-# Special requirements:
-#   Some languages require additional setup/installations.
-#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
-# When using multiple languages, the first language server that supports a given file will be used for that file.
-# The first language is the default language and the respective language server will be used as a fallback.
-# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
-languages:
-- python_ty
-
-# list of additional paths to ignore in this project.
-# Same syntax as gitignore, so you can use * and **.
-# Note: global ignored_paths from serena_config.yml are also applied additively.
+languages: ["python_ty"]
 ignored_paths:
-- ".uncoded"
-
-# list of tool names to exclude.
-# This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project based on the project name or path.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
-#       for example by saying that the information retrieved from a memory file is no longer correct
-#       or no longer relevant for the project.
-#  * `edit_memory`: Replaces content matching a regular expression in a memory.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_file`: Finds files in the given relative paths
-#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
-#  * `find_symbol`: Performs a global (or local) search using the language server backend.
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
-#       for clients that do not read the initial instructions when the MCP server is connected.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
-#       is relevant to the current task. You can infer whether the information
-#       is relevant from the memory file name.
-#       You should not read the same memory file multiple times in the same conversation.
-#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
-#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
-#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
-#       For JB, we use a separate tool.
-#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
-#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
-#  * `safe_delete_symbol`:
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
-#       The memory name should be meaningful.
+  - ".uncoded"
 excluded_tools:
-- execute_shell_command
-
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
-# This extends the existing inclusions (e.g. from the global configuration).
-included_optional_tools: []
-
-# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
-# This cannot be combined with non-empty excluded_tools or included_optional_tools.
-fixed_tools: []
-
-# list of mode names to that are always to be included in the set of active modes
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
-# Otherwise, this setting overrides the global configuration.
-# Set this to [] to disable base modes for this project.
-# Set this to a list of mode names to always include the respective modes for this project.
-base_modes:
-
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
-# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
-# This setting can, in turn, be overridden by CLI parameters (--mode).
-default_modes:
-
-# time budget (seconds) per tool call for the retrieval of additional symbol information
-# such as docstrings or parameter information.
-# This overrides the corresponding setting in the global configuration; see the documentation there.
-# If null or missing, use the setting from the global configuration.
-symbol_info_budget:
-
-# The language backend to use for this project.
-# If not set, the global setting from serena_config.yml is used.
-# Valid values: LSP, JetBrains
-# Note: the backend is fixed at startup. If a project with a different backend
-# is activated post-init, an error will be returned.
-language_backend:
-
-# line ending convention to use when writing source files.
-# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
-# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
-line_ending:
-
-# list of regex patterns which, when matched, mark a memory entry as read‑only.
-# Extends the list from the global configuration, merging the two lists.
-read_only_memory_patterns: []
-
-# list of regex patterns for memories to completely ignore.
-# Matching memories will not appear in list_memories or activate_project output
-# and cannot be accessed via read_memory or write_memory.
-# To access ignored memory files, use the read_file tool on the raw file path.
-# Extends the list from the global configuration, merging the two lists.
-# Example: ["_archive/.*", "_episodes/.*"]
-ignored_memory_patterns: []
-
-# advanced configuration option allowing to configure language server-specific options.
-# Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
-ls_specific_settings: {}
-
-# whether the project is in read-only mode
-# If set to true, all editing tools will be disabled and attempts to use them will result in an error
-# Added on 2025-04-18
-read_only: false
-
-# whether to use project's .gitignore files to ignore files
-ignore_all_files_in_gitignore: true
-
-# initial prompt for the project. It will always be given to the LLM upon activating the project
-# (contrary to the memories, which are loaded on demand).
-initial_prompt: ''
-
-# the encoding used by text files in the project
-# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
-encoding: utf-8
+  - execute_shell_command
+  - list_memories
+  - read_memory
+  - write_memory
+  - edit_memory
+  - delete_memory
+  - rename_memory
+  - onboarding
+  - check_onboarding_performed
+  - initial_instructions
+  - open_dashboard

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,16 +1,166 @@
+# the name by which the project can be referenced within Serena
 project_name: "uncoded"
-languages: ["python_ty"]
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- python_ty
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths:
-  - ".uncoded"
+- ".uncoded"
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
 excluded_tools:
-  - execute_shell_command
-  - list_memories
-  - read_memory
-  - write_memory
-  - edit_memory
-  - delete_memory
-  - rename_memory
-  - onboarding
-  - check_onboarding_performed
-  - initial_instructions
-  - open_dashboard
+- execute_shell_command
+- list_memories
+- read_memory
+- write_memory
+- edit_memory
+- delete_memory
+- rename_memory
+- onboarding
+- check_onboarding_performed
+- initial_instructions
+- open_dashboard
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ''
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: utf-8

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -208,6 +208,7 @@ tests/:
       test_header_does_not_break_yaml_parse:
   test_serena_setup.py:
     REPO_ROOT:
+    EXPECTED_EXCLUDED_TOOLS:
     TestReadProjectName:
       test_reads_name_from_pyproject_toml:
       test_falls_back_to_cwd_name_when_no_pyproject:

--- a/.uncoded/stubs/src/uncoded/serena_setup.pyi
+++ b/.uncoded/stubs/src/uncoded/serena_setup.pyi
@@ -5,28 +5,28 @@ import tomllib
 from pathlib import Path
 from uncoded.config import find_pyproject_toml
 
-SERENA_VERSION = '1.1.2'  # L33
-MCP_SERVER_SERENA = ...  # L35-50
-SERENA_PROJECT_YML = ...  # L52-59
-SERENA_ALLOWED_TOOLS = ...  # L61-79
-_STATUS_VERB = {'wrote': 'Wrote', 'updated': 'Updated', 'unchanged': 'Unchanged'}  # L81-85
+SERENA_VERSION = '1.1.2'  # L38
+MCP_SERVER_SERENA = ...  # L40-55
+SERENA_PROJECT_YML = ...  # L57-74
+SERENA_ALLOWED_TOOLS = ...  # L76-85
+_STATUS_VERB = {'wrote': 'Wrote', 'updated': 'Updated', 'unchanged': 'Unchanged'}  # L87-91
 
-def read_project_name() -> str:  # L88-98
+def read_project_name() -> str:  # L94-104
     """Read the project name from pyproject.toml, falling back to the cwd name."""
     ...
 
-def _sync_mcp_json(path: Path) -> str:  # L101-125
+def _sync_mcp_json(path: Path) -> str:  # L107-131
     """Write or merge Serena into ``.mcp.json``."""
     ...
 
-def _sync_serena_project(path: Path, project_name: str) -> str:  # L128-139
+def _sync_serena_project(path: Path, project_name: str) -> str:  # L134-145
     """Write ``.serena/project.yml`` if absent."""
     ...
 
-def _sync_claude_settings(path: Path) -> str:  # L142-172
+def _sync_claude_settings(path: Path) -> str:  # L148-178
     """Write or merge Serena allowlist into ``.claude/settings.json``."""
     ...
 
-def setup_serena(root: Path | None) -> int:  # L175-197
+def setup_serena(root: Path | None) -> int:  # L181-203
     """Generate Serena + ty + Claude Code configuration under ``root``."""
     ...

--- a/.uncoded/stubs/tests/test_serena_setup.pyi
+++ b/.uncoded/stubs/tests/test_serena_setup.pyi
@@ -7,67 +7,68 @@ import yaml
 from uncoded.serena_setup import SERENA_ALLOWED_TOOLS, SERENA_VERSION, read_project_name, setup_serena
 
 REPO_ROOT = Path(__file__).parent.parent  # L14
+EXPECTED_EXCLUDED_TOOLS = ...  # L20-32
 
-class TestReadProjectName:  # L17-35
+class TestReadProjectName:  # L35-53
 
-    def test_reads_name_from_pyproject_toml(self, tmp_path):  # L18-21
+    def test_reads_name_from_pyproject_toml(self, tmp_path):  # L36-39
         ...
 
-    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L23-25
+    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L41-43
         ...
 
-    def test_falls_back_to_cwd_name_when_no_project_section(self, tmp_path):  # L27-30
+    def test_falls_back_to_cwd_name_when_no_project_section(self, tmp_path):  # L45-48
         ...
 
-    def test_falls_back_to_cwd_name_when_name_missing(self, tmp_path):  # L32-35
+    def test_falls_back_to_cwd_name_when_name_missing(self, tmp_path):  # L50-53
         ...
 
-class TestSetupSerena:  # L38-150
+class TestSetupSerena:  # L56-168
 
-    def _run(self, tmp_path, name):  # L39-42
+    def _run(self, tmp_path, name):  # L57-60
         ...
 
-    def test_creates_all_three_files(self, tmp_path):  # L44-48
+    def test_creates_all_three_files(self, tmp_path):  # L62-66
         ...
 
-    def test_mcp_json_is_valid_and_pins_version(self, tmp_path):  # L50-58
+    def test_mcp_json_is_valid_and_pins_version(self, tmp_path):  # L68-76
         ...
 
-    def test_serena_project_yml_uses_ty_and_ignores_uncoded(self, tmp_path):  # L60-66
+    def test_serena_project_yml_uses_ty_and_ignores_uncoded(self, tmp_path):  # L78-84
         ...
 
-    def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):  # L68-72
+    def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):  # L86-90
         ...
 
-    def test_idempotent(self, tmp_path):  # L74-82
+    def test_idempotent(self, tmp_path):  # L92-100
         ...
 
-    def test_merges_into_existing_mcp_json(self, tmp_path):  # L84-92
+    def test_merges_into_existing_mcp_json(self, tmp_path):  # L102-110
         ...
 
-    def test_refreshes_stale_serena_entry_in_mcp_json(self, tmp_path):  # L94-108
+    def test_refreshes_stale_serena_entry_in_mcp_json(self, tmp_path):  # L112-126
         ...
 
-    def test_merges_into_existing_claude_settings(self, tmp_path):  # L110-126
+    def test_merges_into_existing_claude_settings(self, tmp_path):  # L128-144
         ...
 
-    def test_does_not_overwrite_existing_serena_project_yml(self, tmp_path):  # L128-134
+    def test_does_not_overwrite_existing_serena_project_yml(self, tmp_path):  # L146-152
         ...
 
-    def test_does_not_duplicate_on_second_merge(self, tmp_path):  # L136-144
+    def test_does_not_duplicate_on_second_merge(self, tmp_path):  # L154-162
         ...
 
-    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L146-150
+    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L164-168
         ...
 
-class TestRepoDogfooding:  # L153-180
+class TestRepoDogfooding:  # L171-198
     """Catch drift between setup-serena's templates and this repo's own config."""
 
-    def test_repo_mcp_json_pins_same_serena_version(self):  # L163-166
+    def test_repo_mcp_json_pins_same_serena_version(self):  # L181-184
         ...
 
-    def test_repo_claude_settings_allowlists_every_serena_tool(self):  # L168-174
+    def test_repo_claude_settings_allowlists_every_serena_tool(self):  # L186-192
         ...
 
-    def test_repo_serena_project_yml_matches_template_contract(self):  # L176-180
+    def test_repo_serena_project_yml_matches_template_contract(self):  # L194-198
         ...

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -5,12 +5,17 @@ the Python language-server backend, in the shape Claude Code picks up
 automatically:
 
 * ``.mcp.json`` — registers the Serena MCP server so Claude Code launches
-  it via ``uvx`` on session start.
+  it via ``uvx`` on session start, with the web dashboard disabled.
 * ``.serena/project.yml`` — selects ty over Serena's default backend
-  (pyright), keeps Serena out of uncoded's generated stubs, and drops
-  ``execute_shell_command`` (redundant with the client's own shell).
+  (pyright), keeps Serena out of uncoded's generated stubs, and narrows
+  Serena's surface to pure LSP operations: memory, onboarding,
+  dashboard, and shell-exec tools are all excluded. uncoded's namespace
+  map and stubs already give agents a project-wide view, so Serena's
+  memory-based project understanding is redundant and noisy alongside
+  it.
 * ``.claude/settings.json`` — enables the Serena server and allowlists
-  navigation, rename, and memory tools so they run without a prompt.
+  the eight LSP tools (symbol lookup, reference search, and the edit
+  family) so they run without a prompt.
 
 JSON files merge into existing content: pre-existing non-Serena MCP
 servers and permissions are preserved, while the Serena entry itself
@@ -56,26 +61,27 @@ ignored_paths:
   - ".uncoded"
 excluded_tools:
   - execute_shell_command
+  - list_memories
+  - read_memory
+  - write_memory
+  - edit_memory
+  - delete_memory
+  - rename_memory
+  - onboarding
+  - check_onboarding_performed
+  - initial_instructions
+  - open_dashboard
 """
 
 SERENA_ALLOWED_TOOLS = [
-    "mcp__serena__check_onboarding_performed",
-    "mcp__serena__find_referencing_symbols",
     "mcp__serena__find_symbol",
+    "mcp__serena__find_referencing_symbols",
     "mcp__serena__get_symbols_overview",
-    "mcp__serena__initial_instructions",
-    "mcp__serena__list_memories",
-    "mcp__serena__read_memory",
     "mcp__serena__rename_symbol",
-    "mcp__serena__insert_after_symbol",
-    "mcp__serena__insert_before_symbol",
-    "mcp__serena__replace_symbol_body",
     "mcp__serena__safe_delete_symbol",
-    "mcp__serena__write_memory",
-    "mcp__serena__edit_memory",
-    "mcp__serena__delete_memory",
-    "mcp__serena__rename_memory",
-    "mcp__serena__onboarding",
+    "mcp__serena__insert_before_symbol",
+    "mcp__serena__insert_after_symbol",
+    "mcp__serena__replace_symbol_body",
 ]
 
 _STATUS_VERB = {

--- a/tests/test_serena_setup.py
+++ b/tests/test_serena_setup.py
@@ -13,6 +13,24 @@ from uncoded.serena_setup import (
 
 REPO_ROOT = Path(__file__).parent.parent
 
+# Tools Serena exposes that we strip from the project. Kept in the test
+# module (not the source) so the test asserts the contract independently
+# of the constant it's validating: a typo or silent removal in
+# SERENA_PROJECT_YML shows up here.
+EXPECTED_EXCLUDED_TOOLS = {
+    "execute_shell_command",
+    "list_memories",
+    "read_memory",
+    "write_memory",
+    "edit_memory",
+    "delete_memory",
+    "rename_memory",
+    "onboarding",
+    "check_onboarding_performed",
+    "initial_instructions",
+    "open_dashboard",
+}
+
 
 class TestReadProjectName:
     def test_reads_name_from_pyproject_toml(self, tmp_path):
@@ -63,7 +81,7 @@ class TestSetupSerena:
         assert data["project_name"] == "my-app"
         assert data["languages"] == ["python_ty"]
         assert ".uncoded" in data["ignored_paths"]
-        assert "execute_shell_command" in data["excluded_tools"]
+        assert set(data["excluded_tools"]) == EXPECTED_EXCLUDED_TOOLS
 
     def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):
         self._run(tmp_path)
@@ -177,4 +195,4 @@ class TestRepoDogfooding:
         data = yaml.safe_load((REPO_ROOT / ".serena" / "project.yml").read_text())
         assert data["languages"] == ["python_ty"]
         assert ".uncoded" in data["ignored_paths"]
-        assert "execute_shell_command" in data["excluded_tools"]
+        assert set(data["excluded_tools"]) == EXPECTED_EXCLUDED_TOOLS


### PR DESCRIPTION
## Summary

- Closes #24. uncoded's namespace map + stubs already give agents a project-wide view of the code, so Serena's memory-based project understanding is redundant alongside it — and the onboarding/memory flow is exactly the "extra noise" the issue calls out.
- Extends `excluded_tools` in `.serena/project.yml` to strip the memory family (`list_memories`, `read_memory`, `write_memory`, `edit_memory`, `delete_memory`, `rename_memory`), the onboarding family (`onboarding`, `check_onboarding_performed`, `initial_instructions`), and `open_dashboard`. `execute_shell_command` stays excluded as before.
- Shrinks `SERENA_ALLOWED_TOOLS` to the eight LSP tools agents actually need: `find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `rename_symbol`, `safe_delete_symbol`, `insert_before_symbol`, `insert_after_symbol`, `replace_symbol_body`.
- Regenerates this repo's own `.serena/project.yml` and `.claude/settings.json` from the new templates so dogfooding assertions pass.

## Why `check_onboarding_performed` and `initial_instructions` are also excluded

`check_onboarding_performed` returns "not performed" in any fresh repo and tells the agent to call `onboarding`, which is now absent — leaving it in would dead-end the flow on every session. `initial_instructions` returns Serena's generic agent-guidance prompt which references onboarding and memory as part of the recommended workflow, re-introducing the same confusion. Serena's high-level "use semantic tools, don't read whole files" guidance is still delivered via the MCP server's `instructions` field, which fires automatically on server registration and is independent of `excluded_tools`, so the useful part is preserved.

## Test plan

- [x] `uv run pytest` — 161 passed
- [x] Updated `test_serena_project_yml_uses_ty_and_ignores_uncoded` and the dogfooding `test_repo_serena_project_yml_matches_template_contract` to assert the full `excluded_tools` set, not just one entry, so future drift surfaces here
- [x] Manual grep across the repo confirms no stale references to the removed tool names
- [x] Confirm Serena still starts cleanly on next session with the tightened config

🤖 Generated with [Claude Code](https://claude.com/claude-code)