### PR TITLE
Document coherence review skill in README

### DIFF
--- a/.agents/skills/uncoded-review/SKILL.md
+++ b/.agents/skills/uncoded-review/SKILL.md
@@ -1,22 +1,6 @@
-"""Generate the uncoded-review skill file for the target repository."""
-
-from pathlib import Path
-
-from uncoded.sync import sync_file
-
-SKILL_OUTPUTS = [
-    Path(".claude/skills/uncoded-review/SKILL.md"),  # Claude Code
-    Path(".agents/skills/uncoded-review/SKILL.md"),  # Codex
-]
-
-_SKILL_CONTENT = """\
 ---
 name: uncoded-review
-description: "Perform a coherence review of a Python codebase: a diagnostic sweep \
-for semantic drift, naming inconsistency, promissory mismatch, and structural \
-incoherence. Produces a Markdown report of findings with verbatim evidence and \
-confidence levels, for human investigation. Assumes uncoded is installed \
-(.uncoded/namespace.yaml and .uncoded/stubs/ present)."
+description: "Perform a coherence review of a Python codebase: a diagnostic sweep for semantic drift, naming inconsistency, promissory mismatch, and structural incoherence. Produces a Markdown report of findings with verbatim evidence and confidence levels, for human investigation. Assumes uncoded is installed (.uncoded/namespace.yaml and .uncoded/stubs/ present)."
 ---
 
 # Coherence Review
@@ -373,10 +357,3 @@ files.</scenario>
 semantics of absence differ — e.g. some functions return None on failure while
 others raise, for the same kind of operation.</flag>
 </example>
-"""
-
-
-def sync_skill(*, check: bool) -> bool:
-    """Write the uncoded-review skill file to all supported agent locations."""
-    results = [sync_file(path, _SKILL_CONTENT, check=check) for path in SKILL_OUTPUTS]
-    return any(results)

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -60,7 +60,7 @@ src/:
       _sync_claude_settings:
       setup_serena:
     skill.py:
-      SKILL_OUTPUT:
+      SKILL_OUTPUTS:
       _SKILL_CONTENT:
       sync_skill:
     stubs.py:
@@ -237,7 +237,7 @@ tests/:
       test_repo_serena_project_yml_matches_template_contract:
   test_skill.py:
     TestSyncSkill:
-      test_writes_skill_file:
+      test_writes_skill_files:
       test_creates_parent_directories:
       test_returns_true_on_first_write:
       test_returns_false_when_already_in_sync:

--- a/.uncoded/stubs/src/uncoded/skill.pyi
+++ b/.uncoded/stubs/src/uncoded/skill.pyi
@@ -3,9 +3,9 @@
 from pathlib import Path
 from uncoded.sync import sync_file
 
-SKILL_OUTPUT = Path('.claude/skills/uncoded-review/SKILL.md')  # L7
-_SKILL_CONTENT = ...  # L9-373
+SKILL_OUTPUTS = ...  # L7-10
+_SKILL_CONTENT = ...  # L12-376
 
-def sync_skill(*, check: bool) -> bool:  # L376-378
-    """Write the uncoded-review skill file if it differs from what's on disk."""
+def sync_skill(*, check: bool) -> bool:  # L379-382
+    """Write the uncoded-review skill file to all supported agent locations."""
     ...

--- a/.uncoded/stubs/tests/test_cli.pyi
+++ b/.uncoded/stubs/tests/test_cli.pyi
@@ -5,61 +5,62 @@ import sys
 import textwrap
 import pytest
 from uncoded import cli
+from uncoded.skill import SKILL_OUTPUTS
 
-def _init_repo(tmp_path, source_roots):  # L18-34
+def _init_repo(tmp_path, source_roots):  # L19-35
     """Set up a minimal repo: pyproject.toml + source root + chdir."""
     ...
 
-class TestSyncApplyMode:  # L37-95
+class TestSyncApplyMode:  # L38-91
 
-    def test_writes_namespace_map_stubs_and_instruction_file(self, tmp_path):  # L38-48
+    def test_writes_namespace_map_stubs_and_instruction_file(self, tmp_path):  # L39-48
         ...
 
-    def test_idempotent_second_run(self, tmp_path):  # L50-74
+    def test_idempotent_second_run(self, tmp_path):  # L50-70
         ...
 
-    def test_error_when_no_pyproject_toml(self, tmp_path, capsys):  # L76-79
+    def test_error_when_no_pyproject_toml(self, tmp_path, capsys):  # L72-75
         ...
 
-    def test_error_when_source_root_missing(self, tmp_path, capsys):  # L81-95
+    def test_error_when_source_root_missing(self, tmp_path, capsys):  # L77-91
         ...
 
-class TestSyncCheckMode:  # L98-155
+class TestSyncCheckMode:  # L94-151
 
-    def test_returns_one_and_does_not_write_on_empty_repo(self, tmp_path):  # L99-106
+    def test_returns_one_and_does_not_write_on_empty_repo(self, tmp_path):  # L95-102
         ...
 
-    def test_returns_zero_when_index_is_up_to_date(self, tmp_path):  # L108-112
+    def test_returns_zero_when_index_is_up_to_date(self, tmp_path):  # L104-108
         ...
 
-    def test_returns_one_when_source_changes_after_sync(self, tmp_path):  # L114-125
+    def test_returns_one_when_source_changes_after_sync(self, tmp_path):  # L110-121
         ...
 
-    def test_returns_one_when_source_file_deleted(self, tmp_path):  # L127-136
+    def test_returns_one_when_source_file_deleted(self, tmp_path):  # L123-132
         ...
 
-    def test_returns_one_when_instruction_file_drifts(self, tmp_path):  # L138-149
+    def test_returns_one_when_instruction_file_drifts(self, tmp_path):  # L134-145
         ...
 
-    def test_error_still_returns_one(self, tmp_path, capsys):  # L151-155
+    def test_error_still_returns_one(self, tmp_path, capsys):  # L147-151
         ...
 
-class TestMainDispatch:  # L158-203
+class TestMainDispatch:  # L154-199
 
-    def test_sync_subcommand_runs_in_apply_mode(self, tmp_path, monkeypatch):  # L159-165
+    def test_sync_subcommand_runs_in_apply_mode(self, tmp_path, monkeypatch):  # L155-161
         ...
 
-    def test_check_subcommand_runs_in_check_mode(self, tmp_path, monkeypatch):  # L167-174
+    def test_check_subcommand_runs_in_check_mode(self, tmp_path, monkeypatch):  # L163-170
         ...
 
-    def test_check_subcommand_returns_zero_on_fresh_index(self, tmp_path, monkeypatch):  # L176-182
+    def test_check_subcommand_returns_zero_on_fresh_index(self, tmp_path, monkeypatch):  # L172-178
         ...
 
-    def test_setup_serena_subcommand(self, tmp_path, monkeypatch):  # L184-188
+    def test_setup_serena_subcommand(self, tmp_path, monkeypatch):  # L180-184
         ...
 
-    def test_no_subcommand_is_an_error(self, tmp_path, monkeypatch):  # L190-197
+    def test_no_subcommand_is_an_error(self, tmp_path, monkeypatch):  # L186-193
         ...
 
-    def test_unknown_subcommand_is_an_error(self, tmp_path, monkeypatch):  # L199-203
+    def test_unknown_subcommand_is_an_error(self, tmp_path, monkeypatch):  # L195-199
         ...

--- a/.uncoded/stubs/tests/test_skill.pyi
+++ b/.uncoded/stubs/tests/test_skill.pyi
@@ -1,30 +1,30 @@
 # tests/test_skill.py
 
 import os
-from uncoded.skill import _SKILL_CONTENT, SKILL_OUTPUT, sync_skill
+from uncoded.skill import _SKILL_CONTENT, SKILL_OUTPUTS, sync_skill
 
-class TestSyncSkill:  # L6-47
+class TestSyncSkill:  # L6-52
 
-    def test_writes_skill_file(self, tmp_path):  # L7-12
+    def test_writes_skill_files(self, tmp_path):  # L7-13
         ...
 
-    def test_creates_parent_directories(self, tmp_path):  # L14-17
+    def test_creates_parent_directories(self, tmp_path):  # L15-19
         ...
 
-    def test_returns_true_on_first_write(self, tmp_path):  # L19-21
+    def test_returns_true_on_first_write(self, tmp_path):  # L21-23
         ...
 
-    def test_returns_false_when_already_in_sync(self, tmp_path):  # L23-26
+    def test_returns_false_when_already_in_sync(self, tmp_path):  # L25-28
         ...
 
-    def test_idempotent(self, tmp_path):  # L28-33
+    def test_idempotent(self, tmp_path):  # L30-37
         ...
 
-    def test_check_mode_does_not_write(self, tmp_path):  # L35-38
+    def test_check_mode_does_not_write(self, tmp_path):  # L39-43
         ...
 
-    def test_check_mode_reports_change_when_missing(self, tmp_path):  # L40-42
+    def test_check_mode_reports_change_when_missing(self, tmp_path):  # L45-47
         ...
 
-    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):  # L44-47
+    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):  # L49-52
         ...

--- a/README.md
+++ b/README.md
@@ -13,16 +13,20 @@ Additionally, **uncoded** provides some convenience for setting up your coding a
 
 ## What it generates
 
-Running `uncoded sync` produces two things under `.uncoded/`:
+Running `uncoded sync` produces:
 
-**`namespace.yaml`** — a hierarchical YAML file listing every symbol:
+**`.uncoded/namespace.yaml`** — a hierarchical YAML file listing every symbol:
 directories, files, classes (with attributes and methods), functions. Covers
 all configured source roots. An agent can load this at the start of a task
 and immediately know the full vocabulary of the codebase.
 
-**`stubs/`** — one `.pyi` stub per source file, with imports, full signatures
-(parameter names, types, return types), first-sentence docstrings, and an
-`L<start>-<end>` line range on every definition.
+**`.uncoded/stubs/`** — one `.pyi` stub per source file, with imports, full
+signatures (parameter names, types, return types), first-sentence docstrings,
+and an `L<start>-<end>` line range on every definition.
+
+**`.claude/skills/uncoded-review/SKILL.md`** — a Claude Code skill for running
+a coherence review of the codebase (see [Coherence review](#coherence-review)
+below).
 
 `uncoded` also injects a navigation protocol into `CLAUDE.md`/`AGENTS.md`, so agents
 working in the repo pick up the instructions automatically.
@@ -105,6 +109,37 @@ When `uncoded` is set up, a navigation section is automatically maintained in
 3. Read only the source lines they need, using the `L<start>-<end>` ranges from the stubs.
 
 Three reads to navigate to any symbol in the codebase. No grep.
+
+## Coherence review
+
+AI coding agents tend to leave codebases in an incoherent state: names that
+no longer match behaviour, docstrings that describe stale signatures, dead
+symbols, pattern changes applied in some places but not others. `uncoded sync`
+installs a `/uncoded-review` skill that runs a structured diagnostic sweep to
+find these problems.
+
+Invoke it in Claude Code:
+
+```
+/uncoded-review
+```
+
+The review works in four sweeps:
+
+1. **Orient** — loads `namespace.yaml` and forms a vocabulary map.
+2. **Lexical** — scans the namespace for naming inconsistency: concept
+   duplication, qualifier accretion (`_v2`, `_legacy`, `_final`), vocabulary
+   islands, name collision with drift.
+3. **Promissory** — reads stubs, checking each symbol's name / signature /
+   docstring triple for internal disagreement.
+4. **Structural** — checks for boundary violations (private symbols imported
+   across modules), overgrown public surfaces, cross-domain imports, and
+   zero-caller public symbols.
+
+Output is a timestamped Markdown report saved to `.uncoded/reviews/`, with
+verbatim evidence and a confidence level (high / medium / low) for each
+finding. The review only reports — it proposes no fixes. The human decides
+what to follow up.
 
 ## Using uncoded with a language server
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ and immediately know the full vocabulary of the codebase.
 signatures (parameter names, types, return types), first-sentence docstrings,
 and an `L<start>-<end>` line range on every definition.
 
-**`.claude/skills/uncoded-review/SKILL.md`** — a Claude Code skill for running
-a coherence review of the codebase (see [Coherence review](#coherence-review)
-below).
+**`.claude/skills/uncoded-review/SKILL.md`** and
+**`.agents/skills/uncoded-review/SKILL.md`** — a coherence review skill,
+written to both Claude Code and Codex skill directories (see
+[Coherence review](#coherence-review) below).
 
 `uncoded` also injects a navigation protocol into `CLAUDE.md`/`AGENTS.md`, so agents
 working in the repo pick up the instructions automatically.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ import textwrap
 import pytest
 
 from uncoded import cli
+from uncoded.skill import SKILL_OUTPUTS
 
 
 def _init_repo(tmp_path, source_roots=("src",)):
@@ -43,9 +44,8 @@ class TestSyncApplyMode:
         assert (tmp_path / ".uncoded" / "namespace.yaml").exists()
         assert (tmp_path / ".uncoded" / "stubs" / "src" / "foo.pyi").exists()
         assert (tmp_path / "CLAUDE.md").exists()
-        assert (
-            tmp_path / ".claude" / "skills" / "uncoded-review" / "SKILL.md"
-        ).exists()
+        for skill_path in SKILL_OUTPUTS:
+            assert (tmp_path / skill_path).exists()
 
     def test_idempotent_second_run(self, tmp_path):
         _init_repo(tmp_path)
@@ -56,11 +56,7 @@ class TestSyncApplyMode:
             (tmp_path / ".uncoded" / "stubs" / "src" / "foo.pyi").stat().st_mtime_ns
         )
         claude_mtime = (tmp_path / "CLAUDE.md").stat().st_mtime_ns
-        skill_mtime = (
-            (tmp_path / ".claude" / "skills" / "uncoded-review" / "SKILL.md")
-            .stat()
-            .st_mtime_ns
-        )
+        skill_mtimes = [(tmp_path / p).stat().st_mtime_ns for p in SKILL_OUTPUTS]
 
         # A second run with no source changes must not rewrite any artifact.
         assert cli._sync() == 0
@@ -69,9 +65,9 @@ class TestSyncApplyMode:
             tmp_path / ".uncoded" / "stubs" / "src" / "foo.pyi"
         ).stat().st_mtime_ns == stub_mtime
         assert (tmp_path / "CLAUDE.md").stat().st_mtime_ns == claude_mtime
-        assert (
-            tmp_path / ".claude" / "skills" / "uncoded-review" / "SKILL.md"
-        ).stat().st_mtime_ns == skill_mtime
+        assert [
+            (tmp_path / p).stat().st_mtime_ns for p in SKILL_OUTPUTS
+        ] == skill_mtimes
 
     def test_error_when_no_pyproject_toml(self, tmp_path, capsys):
         os.chdir(tmp_path)

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -1,20 +1,22 @@
 import os
 
-from uncoded.skill import _SKILL_CONTENT, SKILL_OUTPUT, sync_skill
+from uncoded.skill import _SKILL_CONTENT, SKILL_OUTPUTS, sync_skill
 
 
 class TestSyncSkill:
-    def test_writes_skill_file(self, tmp_path):
+    def test_writes_skill_files(self, tmp_path):
         os.chdir(tmp_path)
         sync_skill(check=False)
-        skill_path = tmp_path / SKILL_OUTPUT
-        assert skill_path.exists()
-        assert skill_path.read_text() == _SKILL_CONTENT
+        for path in SKILL_OUTPUTS:
+            skill_path = tmp_path / path
+            assert skill_path.exists()
+            assert skill_path.read_text() == _SKILL_CONTENT
 
     def test_creates_parent_directories(self, tmp_path):
         os.chdir(tmp_path)
         sync_skill(check=False)
-        assert (tmp_path / ".claude" / "skills" / "uncoded-review").is_dir()
+        for path in SKILL_OUTPUTS:
+            assert (tmp_path / path).parent.is_dir()
 
     def test_returns_true_on_first_write(self, tmp_path):
         os.chdir(tmp_path)
@@ -28,14 +30,17 @@ class TestSyncSkill:
     def test_idempotent(self, tmp_path):
         os.chdir(tmp_path)
         sync_skill(check=False)
-        mtime = (tmp_path / SKILL_OUTPUT).stat().st_mtime_ns
+        mtimes = [(tmp_path / path).stat().st_mtime_ns for path in SKILL_OUTPUTS]
         sync_skill(check=False)
-        assert (tmp_path / SKILL_OUTPUT).stat().st_mtime_ns == mtime
+        assert [
+            (tmp_path / path).stat().st_mtime_ns for path in SKILL_OUTPUTS
+        ] == mtimes
 
     def test_check_mode_does_not_write(self, tmp_path):
         os.chdir(tmp_path)
         sync_skill(check=True)
-        assert not (tmp_path / SKILL_OUTPUT).exists()
+        for path in SKILL_OUTPUTS:
+            assert not (tmp_path / path).exists()
 
     def test_check_mode_reports_change_when_missing(self, tmp_path):
         os.chdir(tmp_path)


### PR DESCRIPTION
## Summary

- Documents the coherence review skill in README: adds it to "What it generates" and adds a new "Coherence review" section explaining the four sweeps, invocation, and output format
- Extends skill generation to write to both `.claude/skills/` (Claude Code) and `.agents/skills/` (Codex), with `SKILL_OUTPUTS` as an extensible list
- Tests updated to iterate `SKILL_OUTPUTS` rather than hardcode a single path

## Test plan

- [ ] `uv run pytest` passes (169 tests)
- [ ] `uv run uncoded sync` writes both `.claude/skills/uncoded-review/SKILL.md` and `.agents/skills/uncoded-review/SKILL.md`
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)