### PR TITLE
Derive package version from git tag via hatch-vcs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
       - run: uv python install 3.12
       - run: uv sync --extra dev
@@ -23,6 +25,8 @@ jobs:
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --extra dev

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -10,6 +10,8 @@
 
 src/:
   uncoded/:
+    __init__.py:
+      __version__:
     cli.py:
       DEFAULT_MAP_OUTPUT:
       _sync:
@@ -327,3 +329,4 @@ tests/:
       test_check_mode_reports_noop_when_absent:
   test_uncoded.py:
     test_import:
+    test_version_is_exposed:

--- a/.uncoded/stubs/src/uncoded/__init__.pyi
+++ b/.uncoded/stubs/src/uncoded/__init__.pyi
@@ -1,0 +1,5 @@
+# src/uncoded/__init__.py
+
+from importlib.metadata import version
+
+__version__ = version('uncoded')  # L5

--- a/.uncoded/stubs/tests/test_uncoded.pyi
+++ b/.uncoded/stubs/tests/test_uncoded.pyi
@@ -4,3 +4,6 @@ import uncoded
 
 def test_import():  # L4-5
     ...
+
+def test_version_is_exposed():  # L8-10
+    ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "uncoded"
-version = "0.0.0"
+dynamic = ["version"]
 description = "Here be dragons."
 readme = "README.md"
 license = "MIT"
@@ -33,6 +33,9 @@ uncoded = "uncoded.cli:main"
 [project.urls]
 Homepage = "https://github.com/alimanfoo/uncoded"
 Repository = "https://github.com/alimanfoo/uncoded"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.uncoded]
 source-roots = ["src", "tests"]

--- a/src/uncoded/__init__.py
+++ b/src/uncoded/__init__.py
@@ -1,1 +1,5 @@
 """Uncoded."""
+
+from importlib.metadata import version
+
+__version__ = version("uncoded")

--- a/tests/test_uncoded.py
+++ b/tests/test_uncoded.py
@@ -3,3 +3,8 @@ import uncoded
 
 def test_import():
     assert uncoded is not None
+
+
+def test_version_is_exposed():
+    assert isinstance(uncoded.__version__, str)
+    assert uncoded.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,6 @@ wheels = [
 
 [[package]]
 name = "uncoded"
-version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- Switch `pyproject.toml` from hardcoded `version = "0.0.0"` to `dynamic = ["version"]` sourced from VCS via `hatch-vcs`.
- Bump CI checkout to `fetch-depth: 0` so tags are available when `uv sync` builds the package.
- Expose `uncoded.__version__` at runtime via `importlib.metadata`, so the version is visible from inside Python too — not just in lockfile metadata.

## Why

The hardcoded `0.0.0` meant downstream lockfiles pinning a tag recorded misleading metadata:

```
- pypi: git+https://github.com/alimanfoo/uncoded.git?tag=v0.2.0#...
  name: uncoded
  version: 0.0.0
```

The tag pin is correct and reproducible, but `version: 0.0.0` next to `tag=v0.2.0` looks at a glance like the pin didn't take. After this change, builds from a tagged commit produce a clean version (e.g. `0.5.0`); builds from main produce an informative dev version (e.g. `0.4.1.dev0+g<sha>`).

`uncoded.__version__` is exposed in the same change because the underlying concern is version visibility — fixing the build metadata while leaving runtime introspection still hidden behind silence would ship an incoherent intermediate state.

Closes #23.

## Test plan

- [x] `uv build` on `main` produces `uncoded-0.4.1.dev<N>+g<sha>...`.
- [x] `uv pip install "git+file://...@v0.99.0"` (with a clean cache) produces `uncoded==0.99.0` — verifies tag-pinned installs resolve correctly under both `pip` and `uv`.
- [x] `uv run python -c "import uncoded; print(uncoded.__version__)"` prints the version.
- [x] `uv run pytest` — 170/170 pass (including new `test_version_is_exposed`).
- [x] `uv run pre-commit run --all-files` passes.
- [x] CI green on this PR.
- [ ] After merge, cut a new tag (e.g. v0.5.0) and confirm a downstream lockfile records `version: 0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)