### PR TITLE
Soften "Do not grep" opener in injected navigation protocol

### DIFF
--- a/.uncoded/stubs/src/uncoded/instruction_files.pyi
+++ b/.uncoded/stubs/src/uncoded/instruction_files.pyi
@@ -6,17 +6,17 @@ from uncoded.sync import sync_file
 MARKER_START = '<!-- uncoded:start -->'  # L14
 MARKER_END = '<!-- uncoded:end -->'  # L15
 DEFAULT_INSTRUCTION_FILES = [Path('CLAUDE.md'), Path('AGENTS.md')]  # L17
-_SECTION_BODY = ...  # L19-99
-SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L101
+_SECTION_BODY = ...  # L19-104
+SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L106
 
-def generate_section() -> str:  # L104-106
+def generate_section() -> str:  # L109-111
     """Return the full delimited uncoded section for an instruction file."""
     ...
 
-def _replace_or_append(existing: str, section: str) -> str:  # L109-119
+def _replace_or_append(existing: str, section: str) -> str:  # L114-124
     """Replace the delimited section in existing text, or append it if absent."""
     ...
 
-def sync_instruction_file(path: Path, *, check: bool) -> bool:  # L122-133
+def sync_instruction_file(path: Path, *, check: bool) -> bool:  # L127-138
     """Write or update the uncoded navigation section in an instruction file."""
     ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ uv run pytest
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a symbol index over its source code, designed for AI agents to navigate
 deterministically rather than by grep-and-skim. For source navigation, use
-the index — grep and partial-file reading produce a noisier, slower version
-of what the index already lists in full. (For free-text search elsewhere —
+the index — grep-and-skim produces a noisier, slower version of what the
+index already lists in full. (For free-text search elsewhere —
 Markdown, configs, commit messages — grep remains the right tool. The index
 is about source.)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,12 @@ uv run pytest
 ## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
-a navigation index for AI agents. Do not grep. Do not read whole source files.
+a symbol index over its source code, designed for AI agents to navigate
+deterministically rather than by grep-and-skim. For source navigation, use
+the index — grep and partial-file reading produce a noisier, slower version
+of what the index already lists in full. (For free-text search elsewhere —
+Markdown, configs, commit messages — grep remains the right tool. The index
+is about source.)
 
 **Step 1 — Orient. Do this now, before anything else.** Your first action
 in this session — before answering the user, before any other tool call —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ uv run pytest
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a symbol index over its source code, designed for AI agents to navigate
 deterministically rather than by grep-and-skim. For source navigation, use
-the index — grep and partial-file reading produce a noisier, slower version
-of what the index already lists in full. (For free-text search elsewhere —
+the index — grep-and-skim produces a noisier, slower version of what the
+index already lists in full. (For free-text search elsewhere —
 Markdown, configs, commit messages — grep remains the right tool. The index
 is about source.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,12 @@ uv run pytest
 ## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
-a navigation index for AI agents. Do not grep. Do not read whole source files.
+a symbol index over its source code, designed for AI agents to navigate
+deterministically rather than by grep-and-skim. For source navigation, use
+the index — grep and partial-file reading produce a noisier, slower version
+of what the index already lists in full. (For free-text search elsewhere —
+Markdown, configs, commit messages — grep remains the right tool. The index
+is about source.)
 
 **Step 1 — Orient. Do this now, before anything else.** Your first action
 in this session — before answering the user, before any other tool call —

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -20,7 +20,12 @@ _SECTION_BODY = """\
 ## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
-a navigation index for AI agents. Do not grep. Do not read whole source files.
+a symbol index over its source code, designed for AI agents to navigate
+deterministically rather than by grep-and-skim. For source navigation, use
+the index — grep and partial-file reading produce a noisier, slower version
+of what the index already lists in full. (For free-text search elsewhere —
+Markdown, configs, commit messages — grep remains the right tool. The index
+is about source.)
 
 **Step 1 — Orient. Do this now, before anything else.** Your first action
 in this session — before answering the user, before any other tool call —

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -22,8 +22,8 @@ _SECTION_BODY = """\
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
 a symbol index over its source code, designed for AI agents to navigate
 deterministically rather than by grep-and-skim. For source navigation, use
-the index — grep and partial-file reading produce a noisier, slower version
-of what the index already lists in full. (For free-text search elsewhere —
+the index — grep-and-skim produces a noisier, slower version of what the
+index already lists in full. (For free-text search elsewhere —
 Markdown, configs, commit messages — grep remains the right tool. The index
 is about source.)
 


### PR DESCRIPTION
Closes #22.

## Summary

- The injected navigation protocol opened with two unqualified imperatives ("Do not grep. Do not read whole source files."), which read as an absolute prohibition and conflicts with downstream repos that legitimately grep non-source text (Markdown, configs, commit messages).
- Replaces the opener with a scoped version that leads with what the index is, why grep-and-skim loses for source navigation, and where grep still wins.
- The rest of the protocol (Step 1/2/3 flow, Serena bullets including the correctly-justified "Do not grep for the name" in `find_referencing_symbols`) is unchanged.

## Before

> This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
> a navigation index for AI agents. Do not grep. Do not read whole source files.

## After

> This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
> a symbol index over its source code, designed for AI agents to navigate
> deterministically rather than by grep-and-skim. For source navigation, use
> the index — grep-and-skim produces a noisier, slower version of what the
> index already lists in full. (For free-text search elsewhere —
> Markdown, configs, commit messages — grep remains the right tool. The index
> is about source.)

## Review notes

- An earlier draft used "grep and partial-file reading" in the second sentence, which conflicted with Step 3's mandated `offset`/`limit`-bounded reads. Reworded to reuse the "grep-and-skim" vocabulary already established by the first sentence — captures the unguided failure mode (grep hit, open file, skim around) without catching index-guided partial reads in the same net.

## Test plan

- [x] `uv run pytest` — 170 passed (tests assert on markers/structure, not on opener wording, so no test updates needed).
- [x] `uv run uncoded sync` — refreshes the project's own `CLAUDE.md` and `AGENTS.md` from the new template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)