### PR TITLE
[codex] Allow Serena initial instructions for Codex

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
   ],
   "permissions": {
     "allow": [
+      "mcp__serena__initial_instructions",
       "mcp__serena__find_symbol",
       "mcp__serena__find_referencing_symbols",
       "mcp__serena__get_symbols_overview",

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -87,7 +87,6 @@ excluded_tools:
 - rename_memory
 - onboarding
 - check_onboarding_performed
-- initial_instructions
 - open_dashboard
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).

--- a/.uncoded/stubs/src/uncoded/serena_setup.pyi
+++ b/.uncoded/stubs/src/uncoded/serena_setup.pyi
@@ -7,8 +7,8 @@ from uncoded.config import find_pyproject_toml
 
 SERENA_VERSION = '1.1.2'  # L38
 MCP_SERVER_SERENA = ...  # L40-55
-SERENA_PROJECT_YML = ...  # L57-74
-SERENA_ALLOWED_TOOLS = ...  # L76-85
+SERENA_PROJECT_YML = ...  # L57-73
+SERENA_ALLOWED_TOOLS = ...  # L75-85
 _STATUS_VERB = {'wrote': 'Wrote', 'updated': 'Updated', 'unchanged': 'Unchanged'}  # L87-91
 
 def read_project_name() -> str:  # L94-104

--- a/.uncoded/stubs/tests/test_serena_setup.pyi
+++ b/.uncoded/stubs/tests/test_serena_setup.pyi
@@ -7,68 +7,68 @@ import yaml
 from uncoded.serena_setup import SERENA_ALLOWED_TOOLS, SERENA_VERSION, read_project_name, setup_serena
 
 REPO_ROOT = Path(__file__).parent.parent  # L14
-EXPECTED_EXCLUDED_TOOLS = ...  # L20-32
+EXPECTED_EXCLUDED_TOOLS = ...  # L20-31
 
-class TestReadProjectName:  # L35-53
+class TestReadProjectName:  # L34-52
 
-    def test_reads_name_from_pyproject_toml(self, tmp_path):  # L36-39
+    def test_reads_name_from_pyproject_toml(self, tmp_path):  # L35-38
         ...
 
-    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L41-43
+    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L40-42
         ...
 
-    def test_falls_back_to_cwd_name_when_no_project_section(self, tmp_path):  # L45-48
+    def test_falls_back_to_cwd_name_when_no_project_section(self, tmp_path):  # L44-47
         ...
 
-    def test_falls_back_to_cwd_name_when_name_missing(self, tmp_path):  # L50-53
+    def test_falls_back_to_cwd_name_when_name_missing(self, tmp_path):  # L49-52
         ...
 
-class TestSetupSerena:  # L56-168
+class TestSetupSerena:  # L55-169
 
-    def _run(self, tmp_path, name):  # L57-60
+    def _run(self, tmp_path, name):  # L56-59
         ...
 
-    def test_creates_all_three_files(self, tmp_path):  # L62-66
+    def test_creates_all_three_files(self, tmp_path):  # L61-65
         ...
 
-    def test_mcp_json_is_valid_and_pins_version(self, tmp_path):  # L68-76
+    def test_mcp_json_is_valid_and_pins_version(self, tmp_path):  # L67-75
         ...
 
-    def test_serena_project_yml_uses_ty_and_ignores_uncoded(self, tmp_path):  # L78-84
+    def test_serena_project_yml_uses_ty_and_ignores_uncoded(self, tmp_path):  # L77-84
         ...
 
-    def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):  # L86-90
+    def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):  # L86-91
         ...
 
-    def test_idempotent(self, tmp_path):  # L92-100
+    def test_idempotent(self, tmp_path):  # L93-101
         ...
 
-    def test_merges_into_existing_mcp_json(self, tmp_path):  # L102-110
+    def test_merges_into_existing_mcp_json(self, tmp_path):  # L103-111
         ...
 
-    def test_refreshes_stale_serena_entry_in_mcp_json(self, tmp_path):  # L112-126
+    def test_refreshes_stale_serena_entry_in_mcp_json(self, tmp_path):  # L113-127
         ...
 
-    def test_merges_into_existing_claude_settings(self, tmp_path):  # L128-144
+    def test_merges_into_existing_claude_settings(self, tmp_path):  # L129-145
         ...
 
-    def test_does_not_overwrite_existing_serena_project_yml(self, tmp_path):  # L146-152
+    def test_does_not_overwrite_existing_serena_project_yml(self, tmp_path):  # L147-153
         ...
 
-    def test_does_not_duplicate_on_second_merge(self, tmp_path):  # L154-162
+    def test_does_not_duplicate_on_second_merge(self, tmp_path):  # L155-163
         ...
 
-    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L164-168
+    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L165-169
         ...
 
-class TestRepoDogfooding:  # L171-198
+class TestRepoDogfooding:  # L172-199
     """Catch drift between setup-serena's templates and this repo's own config."""
 
-    def test_repo_mcp_json_pins_same_serena_version(self):  # L181-184
+    def test_repo_mcp_json_pins_same_serena_version(self):  # L182-185
         ...
 
-    def test_repo_claude_settings_allowlists_every_serena_tool(self):  # L186-192
+    def test_repo_claude_settings_allowlists_every_serena_tool(self):  # L187-193
         ...
 
-    def test_repo_serena_project_yml_matches_template_contract(self):  # L194-198
+    def test_repo_serena_project_yml_matches_template_contract(self):  # L195-199
         ...

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -69,11 +69,11 @@ excluded_tools:
   - rename_memory
   - onboarding
   - check_onboarding_performed
-  - initial_instructions
   - open_dashboard
 """
 
 SERENA_ALLOWED_TOOLS = [
+    "mcp__serena__initial_instructions",
     "mcp__serena__find_symbol",
     "mcp__serena__find_referencing_symbols",
     "mcp__serena__get_symbols_overview",

--- a/tests/test_serena_setup.py
+++ b/tests/test_serena_setup.py
@@ -27,7 +27,6 @@ EXPECTED_EXCLUDED_TOOLS = {
     "rename_memory",
     "onboarding",
     "check_onboarding_performed",
-    "initial_instructions",
     "open_dashboard",
 }
 
@@ -82,12 +81,14 @@ class TestSetupSerena:
         assert data["languages"] == ["python_ty"]
         assert ".uncoded" in data["ignored_paths"]
         assert set(data["excluded_tools"]) == EXPECTED_EXCLUDED_TOOLS
+        assert "initial_instructions" not in data["excluded_tools"]
 
     def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):
         self._run(tmp_path)
         data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
         assert data["enabledMcpjsonServers"] == ["serena"]
         assert set(data["permissions"]["allow"]) == set(SERENA_ALLOWED_TOOLS)
+        assert "mcp__serena__initial_instructions" in data["permissions"]["allow"]
 
     def test_idempotent(self, tmp_path):
         self._run(tmp_path)


### PR DESCRIPTION
## Summary

Fixes #29 by making the generated Serena/Codex setup allow `initial_instructions`.

## Changes

- Stop excluding Serena's `initial_instructions` tool in generated `.serena/project.yml` content.
- Add `mcp__serena__initial_instructions` to the generated Claude settings allowlist.
- Update this repo's dogfooding `.serena` and `.claude` configs to match the template contract.
- Add regression assertions and regenerate `.uncoded` stubs.

## Root Cause

Codex tries to call `serena.initial_instructions({})` after MCP activation, but uncoded's generated Serena project config explicitly excluded `initial_instructions`, leaving the tool visible through the client integration but inactive at runtime.

## Validation

- `uv run uncoded sync`
- `uv run pytest tests/test_serena_setup.py`
- `uv run pytest`
- `git diff --check`

Full local suite passed: 170 tests.
