### PR TITLE
[codex] Rename review skill to coherence-review

### DIFF
--- a/.agents/skills/coherence-review/SKILL.md
+++ b/.agents/skills/coherence-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: uncoded-review
+name: coherence-review
 description: "Perform a coherence review of a Python codebase: a diagnostic sweep for semantic drift, naming inconsistency, promissory mismatch, and structural incoherence. Produces a Markdown report of findings with verbatim evidence and confidence levels, for human investigation. Assumes uncoded is installed (.uncoded/namespace.yaml and .uncoded/stubs/ present)."
 ---
 

--- a/.claude/skills/coherence-review/SKILL.md
+++ b/.claude/skills/coherence-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: uncoded-review
+name: coherence-review
 description: "Perform a coherence review of a Python codebase: a diagnostic sweep for semantic drift, naming inconsistency, promissory mismatch, and structural incoherence. Produces a Markdown report of findings with verbatim evidence and confidence levels, for human investigation. Assumes uncoded is installed (.uncoded/namespace.yaml and .uncoded/stubs/ present)."
 ---
 

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -63,6 +63,7 @@ src/:
       setup_serena:
     skill.py:
       SKILL_OUTPUTS:
+      LEGACY_SKILL_OUTPUTS:
       _SKILL_CONTENT:
       sync_skill:
     stubs.py:
@@ -239,6 +240,7 @@ tests/:
       test_repo_serena_project_yml_matches_template_contract:
   test_skill.py:
     TestSyncSkill:
+      test_skill_name_and_output_paths:
       test_writes_skill_files:
       test_creates_parent_directories:
       test_returns_true_on_first_write:
@@ -247,6 +249,8 @@ tests/:
       test_check_mode_does_not_write:
       test_check_mode_reports_change_when_missing:
       test_check_mode_reports_no_change_when_in_sync:
+      test_removes_legacy_skill_files:
+      test_check_mode_reports_legacy_skill_files_without_removing:
   test_stubs.py:
     TestExtractStub:
       test_simple_function:

--- a/.uncoded/stubs/src/uncoded/skill.pyi
+++ b/.uncoded/stubs/src/uncoded/skill.pyi
@@ -1,11 +1,12 @@
 # src/uncoded/skill.py
 
 from pathlib import Path
-from uncoded.sync import sync_file
+from uncoded.sync import remove_file, sync_file
 
 SKILL_OUTPUTS = ...  # L7-10
-_SKILL_CONTENT = ...  # L12-376
+LEGACY_SKILL_OUTPUTS = ...  # L12-15
+_SKILL_CONTENT = ...  # L17-381
 
-def sync_skill(*, check: bool) -> bool:  # L379-382
-    """Write the uncoded-review skill file to all supported agent locations."""
+def sync_skill(*, check: bool) -> bool:  # L384-388
+    """Write the coherence-review skill file to all supported agent locations."""
     ...

--- a/.uncoded/stubs/tests/test_skill.pyi
+++ b/.uncoded/stubs/tests/test_skill.pyi
@@ -1,30 +1,40 @@
 # tests/test_skill.py
 
 import os
-from uncoded.skill import _SKILL_CONTENT, SKILL_OUTPUTS, sync_skill
+from pathlib import Path
+from uncoded.skill import _SKILL_CONTENT, LEGACY_SKILL_OUTPUTS, SKILL_OUTPUTS, sync_skill
 
-class TestSyncSkill:  # L6-52
+class TestSyncSkill:  # L12-90
 
-    def test_writes_skill_files(self, tmp_path):  # L7-13
+    def test_skill_name_and_output_paths(self):  # L13-19
         ...
 
-    def test_creates_parent_directories(self, tmp_path):  # L15-19
+    def test_writes_skill_files(self, tmp_path):  # L21-27
         ...
 
-    def test_returns_true_on_first_write(self, tmp_path):  # L21-23
+    def test_creates_parent_directories(self, tmp_path):  # L29-33
         ...
 
-    def test_returns_false_when_already_in_sync(self, tmp_path):  # L25-28
+    def test_returns_true_on_first_write(self, tmp_path):  # L35-37
         ...
 
-    def test_idempotent(self, tmp_path):  # L30-37
+    def test_returns_false_when_already_in_sync(self, tmp_path):  # L39-42
         ...
 
-    def test_check_mode_does_not_write(self, tmp_path):  # L39-43
+    def test_idempotent(self, tmp_path):  # L44-51
         ...
 
-    def test_check_mode_reports_change_when_missing(self, tmp_path):  # L45-47
+    def test_check_mode_does_not_write(self, tmp_path):  # L53-57
         ...
 
-    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):  # L49-52
+    def test_check_mode_reports_change_when_missing(self, tmp_path):  # L59-61
+        ...
+
+    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):  # L63-66
+        ...
+
+    def test_removes_legacy_skill_files(self, tmp_path):  # L68-78
+        ...
+
+    def test_check_mode_reports_legacy_skill_files_without_removing(self, tmp_path):  # L80-90
         ...

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ and immediately know the full vocabulary of the codebase.
 signatures (parameter names, types, return types), first-sentence docstrings,
 and an `L<start>-<end>` line range on every definition.
 
-**`.claude/skills/uncoded-review/SKILL.md`** and
-**`.agents/skills/uncoded-review/SKILL.md`** — a coherence review skill,
+**`.claude/skills/coherence-review/SKILL.md`** and
+**`.agents/skills/coherence-review/SKILL.md`** — a coherence review skill,
 written to both Claude Code and Codex skill directories (see
 [Coherence review](#coherence-review) below).
 
@@ -116,13 +116,13 @@ Three reads to navigate to any symbol in the codebase. No grep.
 AI coding agents tend to leave codebases in an incoherent state: names that
 no longer match behaviour, docstrings that describe stale signatures, dead
 symbols, pattern changes applied in some places but not others. `uncoded sync`
-installs a `/uncoded-review` skill that runs a structured diagnostic sweep to
+installs a `/coherence-review` skill that runs a structured diagnostic sweep to
 find these problems.
 
 Invoke it in Claude Code:
 
 ```
-/uncoded-review
+/coherence-review
 ```
 
 The review works in four sweeps:

--- a/src/uncoded/skill.py
+++ b/src/uncoded/skill.py
@@ -1,17 +1,22 @@
-"""Generate the uncoded-review skill file for the target repository."""
+"""Generate the coherence-review skill file for the target repository."""
 
 from pathlib import Path
 
-from uncoded.sync import sync_file
+from uncoded.sync import remove_file, sync_file
 
 SKILL_OUTPUTS = [
+    Path(".claude/skills/coherence-review/SKILL.md"),  # Claude Code
+    Path(".agents/skills/coherence-review/SKILL.md"),  # Codex
+]
+
+LEGACY_SKILL_OUTPUTS = [
     Path(".claude/skills/uncoded-review/SKILL.md"),  # Claude Code
     Path(".agents/skills/uncoded-review/SKILL.md"),  # Codex
 ]
 
 _SKILL_CONTENT = """\
 ---
-name: uncoded-review
+name: coherence-review
 description: "Perform a coherence review of a Python codebase: a diagnostic sweep \
 for semantic drift, naming inconsistency, promissory mismatch, and structural \
 incoherence. Produces a Markdown report of findings with verbatim evidence and \
@@ -377,6 +382,7 @@ others raise, for the same kind of operation.</flag>
 
 
 def sync_skill(*, check: bool) -> bool:
-    """Write the uncoded-review skill file to all supported agent locations."""
+    """Write the coherence-review skill file to all supported agent locations."""
     results = [sync_file(path, _SKILL_CONTENT, check=check) for path in SKILL_OUTPUTS]
+    results.extend(remove_file(path, check=check) for path in LEGACY_SKILL_OUTPUTS)
     return any(results)

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -1,9 +1,23 @@
 import os
+from pathlib import Path
 
-from uncoded.skill import _SKILL_CONTENT, SKILL_OUTPUTS, sync_skill
+from uncoded.skill import (
+    _SKILL_CONTENT,
+    LEGACY_SKILL_OUTPUTS,
+    SKILL_OUTPUTS,
+    sync_skill,
+)
 
 
 class TestSyncSkill:
+    def test_skill_name_and_output_paths(self):
+        assert [
+            Path(".claude/skills/coherence-review/SKILL.md"),
+            Path(".agents/skills/coherence-review/SKILL.md"),
+        ] == SKILL_OUTPUTS
+        assert "name: coherence-review\n" in _SKILL_CONTENT
+        assert "name: uncoded-review\n" not in _SKILL_CONTENT
+
     def test_writes_skill_files(self, tmp_path):
         os.chdir(tmp_path)
         sync_skill(check=False)
@@ -50,3 +64,27 @@ class TestSyncSkill:
         os.chdir(tmp_path)
         sync_skill(check=False)
         assert sync_skill(check=True) is False
+
+    def test_removes_legacy_skill_files(self, tmp_path):
+        os.chdir(tmp_path)
+        for path in LEGACY_SKILL_OUTPUTS:
+            legacy_path = tmp_path / path
+            legacy_path.parent.mkdir(parents=True, exist_ok=True)
+            legacy_path.write_text("old skill\n")
+
+        assert sync_skill(check=False) is True
+
+        for path in LEGACY_SKILL_OUTPUTS:
+            assert not (tmp_path / path).exists()
+
+    def test_check_mode_reports_legacy_skill_files_without_removing(self, tmp_path):
+        os.chdir(tmp_path)
+        for path in LEGACY_SKILL_OUTPUTS:
+            legacy_path = tmp_path / path
+            legacy_path.parent.mkdir(parents=True, exist_ok=True)
+            legacy_path.write_text("old skill\n")
+
+        assert sync_skill(check=True) is True
+
+        for path in LEGACY_SKILL_OUTPUTS:
+            assert (tmp_path / path).exists()


### PR DESCRIPTION
## Summary

- Rename the generated review skill from `uncoded-review` to `coherence-review` for Claude Code and Codex skill outputs.
- Remove legacy `uncoded-review` skill files during `uncoded sync` so upgraded repos do not keep both slash commands.
- Update README docs, generated skill artifacts, uncoded stubs/namespace, and focused regression coverage.

Fixes #31.

## Validation

- `uv run pytest tests/test_skill.py tests/test_cli.py`
- `uv run pytest`
- `uv run uncoded check`
