### PR TITLE
[codex] Drop line ranges from generated stubs

### DIFF
--- a/.agents/skills/coherence-review/SKILL.md
+++ b/.agents/skills/coherence-review/SKILL.md
@@ -201,10 +201,10 @@ Check systematically, not by spot-check:
 **Redundant public surface.** A public constant and a public parameterless
 function in the same module where the function's sole body is `return
 <constant>`. Both symbols being public exposes an implementation detail
-unnecessarily — only one needs to be public. Detection: look for parameterless
-public functions with a trivial single-line body (visible from the stub's line
-range), then verify the body with Serena's `find_symbol` with
-`include_body=True` before reporting.
+unnecessarily — only one needs to be public. Detection: use the stubs to find
+public parameterless functions near public constants, then verify each
+candidate body with Serena's `find_symbol` with `include_body=True` before
+reporting.
 
 ## Report format
 
@@ -240,7 +240,7 @@ Regions with two or more findings — examine these first:
   collision-with-drift | name-signature-mismatch | docstring-signature-mismatch |
   docstring-name-mismatch | defensive-docstring | god-module |
   boundary-violation | cross-vocabulary-import | zero-caller
-**Location:** `path/to/file.py` · `ClassName/method_name` · L12–L34
+**Location:** `path/to/file.py` · `ClassName/method_name`
 **Confidence:** high | medium | low
 
 **Evidence:**

--- a/.claude/skills/coherence-review/SKILL.md
+++ b/.claude/skills/coherence-review/SKILL.md
@@ -201,10 +201,10 @@ Check systematically, not by spot-check:
 **Redundant public surface.** A public constant and a public parameterless
 function in the same module where the function's sole body is `return
 <constant>`. Both symbols being public exposes an implementation detail
-unnecessarily — only one needs to be public. Detection: look for parameterless
-public functions with a trivial single-line body (visible from the stub's line
-range), then verify the body with Serena's `find_symbol` with
-`include_body=True` before reporting.
+unnecessarily — only one needs to be public. Detection: use the stubs to find
+public parameterless functions near public constants, then verify each
+candidate body with Serena's `find_symbol` with `include_body=True` before
+reporting.
 
 ## Report format
 
@@ -240,7 +240,7 @@ Regions with two or more findings — examine these first:
   collision-with-drift | name-signature-mismatch | docstring-signature-mismatch |
   docstring-name-mismatch | defensive-docstring | god-module |
   boundary-violation | cross-vocabulary-import | zero-caller
-**Location:** `path/to/file.py` · `ClassName/method_name` · L12–L34
+**Location:** `path/to/file.py` · `ClassName/method_name`
 **Confidence:** high | medium | low
 
 **Evidence:**

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -5,7 +5,7 @@
 # Directory keys end with "/". Entries within a file or class appear
 # in source order.
 #
-# For signatures, types, and line ranges, see stubs:
+# For signatures and types, see stubs:
 #   src/foo/bar.py  →  .uncoded/stubs/src/foo/bar.pyi
 
 src/:
@@ -77,22 +77,16 @@ src/:
         params:
         return_annotation:
         docstring_excerpt:
-        start_line:
-        end_line:
         is_async:
       StubAssignment:
         name:
         annotation:
         value_source:
-        start_line:
-        end_line:
         is_type_alias:
       StubClass:
         name:
         bases:
         docstring_excerpt:
-        start_line:
-        end_line:
         attributes:
         methods:
       StubModule:
@@ -103,7 +97,6 @@ src/:
         functions:
       _first_sentence:
       _extract_params:
-      _line_range:
       _render_value:
       _extract_assignment:
       _extract_function:
@@ -258,7 +251,6 @@ tests/:
       test_async_function:
       test_private_function_included:
       test_class_with_attributes_and_methods:
-      test_class_line_range:
       test_class_with_bases:
       test_class_no_bases:
       test_docstring_first_sentence_only:
@@ -282,13 +274,11 @@ tests/:
     TestRenderStub:
       test_header_contains_path:
       test_imports_rendered:
-      test_function_line_range:
+      test_rendered_stub_has_no_line_range_comments:
       test_async_function_prefix:
       test_function_with_annotations:
       test_docstring_excerpt_rendered:
       test_class_with_bases:
-      test_class_single_line_range:
-      test_function_single_line_range:
       test_class_no_bases:
       test_attribute_with_annotation:
       test_method_indented:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -107,7 +107,6 @@ src/:
       _render_function:
       _format_assignment_body:
       _render_assignment:
-      _render_class_attribute:
       render_stub:
       _generate_stubs:
       build_stubs:

--- a/.uncoded/stubs/src/uncoded/__init__.pyi
+++ b/.uncoded/stubs/src/uncoded/__init__.pyi
@@ -2,4 +2,4 @@
 
 from importlib.metadata import version
 
-__version__ = version('uncoded')  # L5
+__version__ = version('uncoded')

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -12,12 +12,12 @@ from uncoded.skill import sync_skill
 from uncoded.stubs import build_stubs
 from uncoded.sync import sync_file
 
-DEFAULT_MAP_OUTPUT = Path('.uncoded/namespace.yaml')  # L16
+DEFAULT_MAP_OUTPUT = Path('.uncoded/namespace.yaml')
 
-def _sync(*, check: bool) -> int:  # L19-61
+def _sync(*, check: bool) -> int:
     """Sync (or verify) the namespace map, stub files, and instruction-file sections."""
     ...
 
-def main() -> int:  # L64-103
+def main() -> int:
     """Dispatch the uncoded CLI."""
     ...

--- a/.uncoded/stubs/src/uncoded/config.pyi
+++ b/.uncoded/stubs/src/uncoded/config.pyi
@@ -4,14 +4,14 @@ import tomllib
 from pathlib import Path
 from uncoded.instruction_files import DEFAULT_INSTRUCTION_FILES
 
-def find_pyproject_toml() -> Path | None:  # L9-19
+def find_pyproject_toml() -> Path | None:
     """Search for pyproject.toml starting from cwd, walking up."""
     ...
 
-def read_source_roots() -> list[Path]:  # L22-40
+def read_source_roots() -> list[Path]:
     """Read source roots from [tool.uncoded] source-roots in pyproject.toml."""
     ...
 
-def read_instruction_files() -> list[Path]:  # L43-62
+def read_instruction_files() -> list[Path]:
     """Read instruction files from [tool.uncoded] instruction-files in pyproject.toml."""
     ...

--- a/.uncoded/stubs/src/uncoded/extract.pyi
+++ b/.uncoded/stubs/src/uncoded/extract.pyi
@@ -5,34 +5,34 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-def _property_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:  # L28-41
+def _property_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
     """Classify a method by its property-related decorators."""
     ...
 
-def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:  # L44-52
+def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:
     """Return the single-name target of an assignment, or None if not a simple name."""
     ...
 
-def extract_module(source: str, rel_path: str) -> ModuleInfo:  # L55-97
+def extract_module(source: str, rel_path: str) -> ModuleInfo:
     """Parse Python source and extract classes, functions, and constants."""
     ...
 
-def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[str, str]]:  # L100-115
+def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[str, str]]:
     """Yield (source_text, rel_path) for every Python file under *source_root*."""
     ...
 
-def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:  # L118-137
+def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files."""
     ...
 
-class ClassInfo:  # L10-15
+class ClassInfo:
     """A class with its attributes and methods."""
 
     name: str
     attributes: list[str] = field(default_factory=list)
     methods: list[str] = field(default_factory=list)
 
-class ModuleInfo:  # L19-25
+class ModuleInfo:
     """Symbols found in a single Python module."""
 
     rel_path: str

--- a/.uncoded/stubs/src/uncoded/instruction_files.pyi
+++ b/.uncoded/stubs/src/uncoded/instruction_files.pyi
@@ -3,20 +3,20 @@
 from pathlib import Path
 from uncoded.sync import sync_file
 
-MARKER_START = '<!-- uncoded:start -->'  # L14
-MARKER_END = '<!-- uncoded:end -->'  # L15
-DEFAULT_INSTRUCTION_FILES = [Path('CLAUDE.md'), Path('AGENTS.md')]  # L17
-_SECTION_BODY = ...  # L19-104
-SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'  # L106
+MARKER_START = '<!-- uncoded:start -->'
+MARKER_END = '<!-- uncoded:end -->'
+DEFAULT_INSTRUCTION_FILES = [Path('CLAUDE.md'), Path('AGENTS.md')]
+_SECTION_BODY = ...
+SECTION = f'{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n'
 
-def generate_section() -> str:  # L109-111
+def generate_section() -> str:
     """Return the full delimited uncoded section for an instruction file."""
     ...
 
-def _replace_or_append(existing: str, section: str) -> str:  # L114-124
+def _replace_or_append(existing: str, section: str) -> str:
     """Replace the delimited section in existing text, or append it if absent."""
     ...
 
-def sync_instruction_file(path: Path, *, check: bool) -> bool:  # L127-138
+def sync_instruction_file(path: Path, *, check: bool) -> bool:
     """Write or update the uncoded navigation section in an instruction file."""
     ...

--- a/.uncoded/stubs/src/uncoded/namespace_map.pyi
+++ b/.uncoded/stubs/src/uncoded/namespace_map.pyi
@@ -4,19 +4,19 @@ from pathlib import Path
 import yaml
 from uncoded.extract import ModuleInfo
 
-HEADER = ...  # L9-19
+HEADER = ...
 
-def build_map(modules: list[ModuleInfo]) -> dict:  # L37-73
+def build_map(modules: list[ModuleInfo]) -> dict:
     """Build a nested dict representing the namespace."""
     ...
 
-def render_map(namespace: dict) -> str:  # L76-84
+def render_map(namespace: dict) -> str:
     """Render a namespace map dict as a YAML string with an explanatory header."""
     ...
 
-class _CleanDumper(yaml.SafeDumper):  # L22-27
+class _CleanDumper(yaml.SafeDumper):
     """YAML dumper that indents list items and suppresses 'null' values."""
 
-    def increase_indent(self, flow, indentless):  # L25-27
+    def increase_indent(self, flow, indentless):
         """Force list items to be indented relative to their parent key."""
         ...

--- a/.uncoded/stubs/src/uncoded/serena_setup.pyi
+++ b/.uncoded/stubs/src/uncoded/serena_setup.pyi
@@ -5,28 +5,28 @@ import tomllib
 from pathlib import Path
 from uncoded.config import find_pyproject_toml
 
-SERENA_VERSION = '1.1.2'  # L38
-MCP_SERVER_SERENA = ...  # L40-55
-SERENA_PROJECT_YML = ...  # L57-73
-SERENA_ALLOWED_TOOLS = ...  # L75-85
-_STATUS_VERB = {'wrote': 'Wrote', 'updated': 'Updated', 'unchanged': 'Unchanged'}  # L87-91
+SERENA_VERSION = '1.1.2'
+MCP_SERVER_SERENA = ...
+SERENA_PROJECT_YML = ...
+SERENA_ALLOWED_TOOLS = ...
+_STATUS_VERB = {'wrote': 'Wrote', 'updated': 'Updated', 'unchanged': 'Unchanged'}
 
-def read_project_name() -> str:  # L94-104
+def read_project_name() -> str:
     """Read the project name from pyproject.toml, falling back to the cwd name."""
     ...
 
-def _sync_mcp_json(path: Path) -> str:  # L107-131
+def _sync_mcp_json(path: Path) -> str:
     """Write or merge Serena into ``.mcp.json``."""
     ...
 
-def _sync_serena_project(path: Path, project_name: str) -> str:  # L134-145
+def _sync_serena_project(path: Path, project_name: str) -> str:
     """Write ``.serena/project.yml`` if absent."""
     ...
 
-def _sync_claude_settings(path: Path) -> str:  # L148-178
+def _sync_claude_settings(path: Path) -> str:
     """Write or merge Serena allowlist into ``.claude/settings.json``."""
     ...
 
-def setup_serena(root: Path | None) -> int:  # L181-203
+def setup_serena(root: Path | None) -> int:
     """Generate Serena + ty + Claude Code configuration under ``root``."""
     ...

--- a/.uncoded/stubs/src/uncoded/skill.pyi
+++ b/.uncoded/stubs/src/uncoded/skill.pyi
@@ -3,10 +3,10 @@
 from pathlib import Path
 from uncoded.sync import remove_file, sync_file
 
-SKILL_OUTPUTS = ...  # L7-10
-LEGACY_SKILL_OUTPUTS = ...  # L12-15
-_SKILL_CONTENT = ...  # L17-381
+SKILL_OUTPUTS = ...
+LEGACY_SKILL_OUTPUTS = ...
+_SKILL_CONTENT = ...
 
-def sync_skill(*, check: bool) -> bool:  # L384-388
+def sync_skill(*, check: bool) -> bool:
     """Write the coherence-review skill file to all supported agent locations."""
     ...

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -7,116 +7,106 @@ from pathlib import Path
 from uncoded.extract import _property_kind, iter_source_files
 from uncoded.sync import remove_file, sync_file
 
-VALUE_WIDTH_CAP = 80  # L13
-DEFAULT_STUBS_OUTPUT = Path('.uncoded/stubs')  # L371
+VALUE_WIDTH_CAP = 80
+DEFAULT_STUBS_OUTPUT = Path('.uncoded/stubs')
 
-def _first_sentence(node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module) -> str | None:  # L78-89
+def _first_sentence(node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module) -> str | None:
     """Return the first sentence of a node's docstring, or None."""
     ...
 
-def _extract_params(args: ast.arguments) -> list[StubParam]:  # L92-124
+def _extract_params(args: ast.arguments) -> list[StubParam]:
     """Extract parameters from a function argument node, without defaults."""
     ...
 
-def _line_range(start: int, end: int) -> str:  # L127-129
-    """Render a line range: 'L<start>' if single-line, else 'L<start>-<end>'."""
-    ...
-
-def _render_value(value: ast.expr) -> str:  # L132-137
+def _render_value(value: ast.expr) -> str:
     """Render an expression as source, eliding to '...' if too long or multi-line."""
     ...
 
-def _extract_assignment(node: ast.Assign | ast.AnnAssign | ast.TypeAlias) -> StubAssignment | None:  # L140-183
+def _extract_assignment(node: ast.Assign | ast.AnnAssign | ast.TypeAlias) -> StubAssignment | None:
     """Build a StubAssignment from an assignment-style AST node."""
     ...
 
-def _extract_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubFunction:  # L186-198
+def _extract_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubFunction:
     """Build a StubFunction from a function or method AST node."""
     ...
 
-def _property_attribute(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubAssignment:  # L201-212
+def _property_attribute(node: ast.FunctionDef | ast.AsyncFunctionDef) -> StubAssignment:
     """Build a StubAssignment representing a @property as a class attribute."""
     ...
 
-def _extract_class(node: ast.ClassDef) -> StubClass:  # L215-244
+def _extract_class(node: ast.ClassDef) -> StubClass:
     """Build a StubClass from a class AST node."""
     ...
 
-def extract_stub(source: str, rel_path: str) -> StubModule:  # L247-273
-    """Parse Python source and extract all symbols with signatures and line ranges."""
+def extract_stub(source: str, rel_path: str) -> StubModule:
+    """Parse Python source and extract all symbols with signatures."""
     ...
 
-def _render_param(p: StubParam) -> str:  # L276-282
+def _render_param(p: StubParam) -> str:
     """Render a single parameter as a string for a function signature."""
     ...
 
-def _render_function(func: StubFunction, indent: str) -> list[str]:  # L285-296
+def _render_function(func: StubFunction, indent: str) -> list[str]:
     """Render a function or method as stub lines, indented for methods."""
     ...
 
-def _format_assignment_body(a: StubAssignment) -> str:  # L299-306
+def _format_assignment_body(a: StubAssignment) -> str:
     """Render the 'name [: type] [= value]' portion of an assignment."""
     ...
 
-def _render_assignment(a: StubAssignment, indent: str) -> str:  # L309-312
-    """Render a module-level assignment as a stub line, with line range."""
+def _render_assignment(a: StubAssignment, indent: str) -> str:
+    """Render a module-level assignment as a stub line."""
     ...
 
-def _render_class_attribute(a: StubAssignment, indent: str) -> str:  # L315-317
-    """Render a class attribute as a stub line (no line range — class has one)."""
+def _render_class_attribute(a: StubAssignment, indent: str) -> str:
+    """Render a class attribute as a stub line."""
     ...
 
-def render_stub(module: StubModule) -> str:  # L320-354
+def render_stub(module: StubModule) -> str:
     """Render a StubModule as a .pyi file string."""
     ...
 
-def _generate_stubs(source_root: Path) -> dict[Path, str]:  # L357-368
+def _generate_stubs(source_root: Path) -> dict[Path, str]:
     """Return a mapping from stub relative paths to rendered stub content."""
     ...
 
-def build_stubs(source_root: Path, output_dir: Path, *, check: bool) -> int:  # L374-423
+def build_stubs(source_root: Path, output_dir: Path, *, check: bool) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans."""
     ...
 
-class StubParam:  # L17-21
+class StubParam:
     """A function parameter with name and optional type annotation."""
 
     name: str
     annotation: str | None = None
 
-class StubFunction:  # L25-34
-    """A function or method with its signature and line range."""
+class StubFunction:
+    """A function or method with its signature."""
 
     name: str
     params: list[StubParam] = field(default_factory=list)
     return_annotation: str | None = None
     docstring_excerpt: str | None = None
-    start_line: int = 0
-    end_line: int = 0
     is_async: bool = False
 
-class StubAssignment:  # L38-51
+class StubAssignment:
     """A module-level or class-level assignment."""
 
     name: str
     annotation: str | None = None
     value_source: str | None = None
-    start_line: int = 0
-    end_line: int = 0
     is_type_alias: bool = False
 
-class StubClass:  # L55-64
-    """A class with its members and line range."""
+class StubClass:
+    """A class with its members."""
 
     name: str
     bases: list[str] = field(default_factory=list)
     docstring_excerpt: str | None = None
-    start_line: int = 0
-    end_line: int = 0
     attributes: list[StubAssignment] = field(default_factory=list)
     methods: list[StubFunction] = field(default_factory=list)
 
-class StubModule:  # L68-75
+class StubModule:
     """All symbols extracted from a single Python module."""
 
     rel_path: str

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -39,7 +39,7 @@ def _extract_class(node: ast.ClassDef) -> StubClass:
     ...
 
 def extract_stub(source: str, rel_path: str) -> StubModule:
-    """Parse Python source and extract all symbols with signatures."""
+    """Parse Python source and extract imports, constants, classes, and functions."""
     ...
 
 def _render_param(p: StubParam) -> str:
@@ -56,10 +56,6 @@ def _format_assignment_body(a: StubAssignment) -> str:
 
 def _render_assignment(a: StubAssignment, indent: str) -> str:
     """Render a module-level assignment as a stub line."""
-    ...
-
-def _render_class_attribute(a: StubAssignment, indent: str) -> str:
-    """Render a class attribute as a stub line."""
     ...
 
 def render_stub(module: StubModule) -> str:

--- a/.uncoded/stubs/src/uncoded/sync.pyi
+++ b/.uncoded/stubs/src/uncoded/sync.pyi
@@ -2,10 +2,10 @@
 
 from pathlib import Path
 
-def sync_file(path: Path, content: str, *, check: bool) -> bool:  # L16-35
+def sync_file(path: Path, content: str, *, check: bool) -> bool:
     """Write ``content`` to ``path`` if it differs from what's on disk."""
     ...
 
-def remove_file(path: Path, *, check: bool) -> bool:  # L38-50
+def remove_file(path: Path, *, check: bool) -> bool:
     """Remove ``path`` if it exists."""
     ...

--- a/.uncoded/stubs/tests/test_cli.pyi
+++ b/.uncoded/stubs/tests/test_cli.pyi
@@ -7,60 +7,60 @@ import pytest
 from uncoded import cli
 from uncoded.skill import SKILL_OUTPUTS
 
-def _init_repo(tmp_path, source_roots):  # L19-35
+def _init_repo(tmp_path, source_roots):
     """Set up a minimal repo: pyproject.toml + source root + chdir."""
     ...
 
-class TestSyncApplyMode:  # L38-91
+class TestSyncApplyMode:
 
-    def test_writes_namespace_map_stubs_and_instruction_file(self, tmp_path):  # L39-48
+    def test_writes_namespace_map_stubs_and_instruction_file(self, tmp_path):
         ...
 
-    def test_idempotent_second_run(self, tmp_path):  # L50-70
+    def test_idempotent_second_run(self, tmp_path):
         ...
 
-    def test_error_when_no_pyproject_toml(self, tmp_path, capsys):  # L72-75
+    def test_error_when_no_pyproject_toml(self, tmp_path, capsys):
         ...
 
-    def test_error_when_source_root_missing(self, tmp_path, capsys):  # L77-91
+    def test_error_when_source_root_missing(self, tmp_path, capsys):
         ...
 
-class TestSyncCheckMode:  # L94-151
+class TestSyncCheckMode:
 
-    def test_returns_one_and_does_not_write_on_empty_repo(self, tmp_path):  # L95-102
+    def test_returns_one_and_does_not_write_on_empty_repo(self, tmp_path):
         ...
 
-    def test_returns_zero_when_index_is_up_to_date(self, tmp_path):  # L104-108
+    def test_returns_zero_when_index_is_up_to_date(self, tmp_path):
         ...
 
-    def test_returns_one_when_source_changes_after_sync(self, tmp_path):  # L110-121
+    def test_returns_one_when_source_changes_after_sync(self, tmp_path):
         ...
 
-    def test_returns_one_when_source_file_deleted(self, tmp_path):  # L123-132
+    def test_returns_one_when_source_file_deleted(self, tmp_path):
         ...
 
-    def test_returns_one_when_instruction_file_drifts(self, tmp_path):  # L134-145
+    def test_returns_one_when_instruction_file_drifts(self, tmp_path):
         ...
 
-    def test_error_still_returns_one(self, tmp_path, capsys):  # L147-151
+    def test_error_still_returns_one(self, tmp_path, capsys):
         ...
 
-class TestMainDispatch:  # L154-199
+class TestMainDispatch:
 
-    def test_sync_subcommand_runs_in_apply_mode(self, tmp_path, monkeypatch):  # L155-161
+    def test_sync_subcommand_runs_in_apply_mode(self, tmp_path, monkeypatch):
         ...
 
-    def test_check_subcommand_runs_in_check_mode(self, tmp_path, monkeypatch):  # L163-170
+    def test_check_subcommand_runs_in_check_mode(self, tmp_path, monkeypatch):
         ...
 
-    def test_check_subcommand_returns_zero_on_fresh_index(self, tmp_path, monkeypatch):  # L172-178
+    def test_check_subcommand_returns_zero_on_fresh_index(self, tmp_path, monkeypatch):
         ...
 
-    def test_setup_serena_subcommand(self, tmp_path, monkeypatch):  # L180-184
+    def test_setup_serena_subcommand(self, tmp_path, monkeypatch):
         ...
 
-    def test_no_subcommand_is_an_error(self, tmp_path, monkeypatch):  # L186-193
+    def test_no_subcommand_is_an_error(self, tmp_path, monkeypatch):
         ...
 
-    def test_unknown_subcommand_is_an_error(self, tmp_path, monkeypatch):  # L195-199
+    def test_unknown_subcommand_is_an_error(self, tmp_path, monkeypatch):
         ...

--- a/.uncoded/stubs/tests/test_config.pyi
+++ b/.uncoded/stubs/tests/test_config.pyi
@@ -6,38 +6,38 @@ import pytest
 from uncoded.config import find_pyproject_toml, read_instruction_files, read_source_roots
 from uncoded.instruction_files import DEFAULT_INSTRUCTION_FILES
 
-class TestFindPyprojectToml:  # L14-29
+class TestFindPyprojectToml:
 
-    def test_finds_in_cwd(self, tmp_path):  # L15-18
+    def test_finds_in_cwd(self, tmp_path):
         ...
 
-    def test_finds_in_parent(self, tmp_path):  # L20-25
+    def test_finds_in_parent(self, tmp_path):
         ...
 
-    def test_returns_none_if_not_found(self, tmp_path):  # L27-29
+    def test_returns_none_if_not_found(self, tmp_path):
         ...
 
-class TestReadSourceRoots:  # L32-50
+class TestReadSourceRoots:
 
-    def test_reads_source_roots(self, tmp_path):  # L33-39
+    def test_reads_source_roots(self, tmp_path):
         ...
 
-    def test_raises_if_no_pyproject_toml(self, tmp_path):  # L41-44
+    def test_raises_if_no_pyproject_toml(self, tmp_path):
         ...
 
-    def test_raises_if_no_uncoded_section(self, tmp_path):  # L46-50
+    def test_raises_if_no_uncoded_section(self, tmp_path):
         ...
 
-class TestReadInstructionFiles:  # L53-83
+class TestReadInstructionFiles:
 
-    def test_returns_default_when_no_pyproject_toml(self, tmp_path):  # L54-56
+    def test_returns_default_when_no_pyproject_toml(self, tmp_path):
         ...
 
-    def test_returns_default_when_key_absent(self, tmp_path):  # L58-63
+    def test_returns_default_when_key_absent(self, tmp_path):
         ...
 
-    def test_reads_configured_list(self, tmp_path):  # L65-76
+    def test_reads_configured_list(self, tmp_path):
         ...
 
-    def test_empty_list_is_respected(self, tmp_path):  # L78-83
+    def test_empty_list_is_respected(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_extract.pyi
+++ b/.uncoded/stubs/tests/test_extract.pyi
@@ -3,60 +3,60 @@
 import textwrap
 from uncoded.extract import extract_module, walk_source
 
-class TestExtractModule:  # L6-205
+class TestExtractModule:
 
-    def test_classes_and_functions(self):  # L7-35
+    def test_classes_and_functions(self):
         ...
 
-    def test_async_functions_and_methods(self):  # L37-54
+    def test_async_functions_and_methods(self):
         ...
 
-    def test_empty_module(self):  # L56-60
+    def test_empty_module(self):
         ...
 
-    def test_module_level_constants(self):  # L62-71
+    def test_module_level_constants(self):
         ...
 
-    def test_type_alias_classic(self):  # L73-81
+    def test_type_alias_classic(self):
         ...
 
-    def test_type_alias_pep695(self):  # L83-91
+    def test_type_alias_pep695(self):
         ...
 
-    def test_tuple_unpacking_skipped(self):  # L93-100
+    def test_tuple_unpacking_skipped(self):
         ...
 
-    def test_unannotated_class_variable(self):  # L102-113
+    def test_unannotated_class_variable(self):
         ...
 
-    def test_module_with_only_constants_is_kept(self, tmp_path):  # L115-124
+    def test_module_with_only_constants_is_kept(self, tmp_path):
         ...
 
-    def test_annotated_attributes(self):  # L126-145
+    def test_annotated_attributes(self):
         ...
 
-    def test_property_classified_as_attribute(self):  # L147-162
+    def test_property_classified_as_attribute(self):
         ...
 
-    def test_property_setter_and_deleter_suppressed(self):  # L164-184
+    def test_property_setter_and_deleter_suppressed(self):
         ...
 
-    def test_preserves_source_order(self):  # L186-205
+    def test_preserves_source_order(self):
         ...
 
-class TestWalkSource:  # L208-287
+class TestWalkSource:
 
-    def test_basic_walk(self, tmp_path):  # L209-234
+    def test_basic_walk(self, tmp_path):
         ...
 
-    def test_nested_subpackage(self, tmp_path):  # L236-248
+    def test_nested_subpackage(self, tmp_path):
         ...
 
-    def test_includes_init_with_symbols(self, tmp_path):  # L250-261
+    def test_includes_init_with_symbols(self, tmp_path):
         ...
 
-    def test_skips_empty_init(self, tmp_path):  # L263-273
+    def test_skips_empty_init(self, tmp_path):
         ...
 
-    def test_skips_syntax_errors(self, tmp_path):  # L275-287
+    def test_skips_syntax_errors(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_instruction_files.pyi
+++ b/.uncoded/stubs/tests/test_instruction_files.pyi
@@ -2,47 +2,47 @@
 
 from uncoded.instruction_files import MARKER_END, MARKER_START, generate_section, sync_instruction_file
 
-class TestGenerateSection:  # L9-20
+class TestGenerateSection:
 
-    def test_contains_markers(self):  # L10-13
+    def test_contains_markers(self):
         ...
 
-    def test_markers_in_order(self):  # L15-17
+    def test_markers_in_order(self):
         ...
 
-    def test_ends_with_newline(self):  # L19-20
+    def test_ends_with_newline(self):
         ...
 
-class TestSyncInstructionFile:  # L23-70
+class TestSyncInstructionFile:
 
-    def test_creates_file_if_missing(self, tmp_path):  # L24-28
+    def test_creates_file_if_missing(self, tmp_path):
         ...
 
-    def test_appends_to_existing_file(self, tmp_path):  # L30-36
+    def test_appends_to_existing_file(self, tmp_path):
         ...
 
-    def test_replaces_existing_section(self, tmp_path):  # L38-46
+    def test_replaces_existing_section(self, tmp_path):
         ...
 
-    def test_preserves_content_after_section(self, tmp_path):  # L48-54
+    def test_preserves_content_after_section(self, tmp_path):
         ...
 
-    def test_idempotent(self, tmp_path):  # L56-61
+    def test_idempotent(self, tmp_path):
         ...
 
-    def test_returns_true_on_first_write(self, tmp_path):  # L63-65
+    def test_returns_true_on_first_write(self, tmp_path):
         ...
 
-    def test_returns_false_when_clean(self, tmp_path):  # L67-70
+    def test_returns_false_when_clean(self, tmp_path):
         ...
 
-class TestSyncInstructionFileCheckMode:  # L73-92
+class TestSyncInstructionFileCheckMode:
 
-    def test_does_not_create_file(self, tmp_path):  # L74-78
+    def test_does_not_create_file(self, tmp_path):
         ...
 
-    def test_does_not_update_existing_file(self, tmp_path):  # L80-86
+    def test_does_not_update_existing_file(self, tmp_path):
         ...
 
-    def test_reports_no_change_when_clean(self, tmp_path):  # L88-92
+    def test_reports_no_change_when_clean(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_namespace_map.pyi
+++ b/.uncoded/stubs/tests/test_namespace_map.pyi
@@ -4,51 +4,51 @@ import yaml
 from uncoded.extract import ClassInfo, ModuleInfo
 from uncoded.namespace_map import HEADER, build_map, render_map
 
-class TestBuildMap:  # L7-146
+class TestBuildMap:
 
-    def test_single_file(self):  # L8-23
+    def test_single_file(self):
         ...
 
-    def test_nested_subpackage(self):  # L25-42
+    def test_nested_subpackage(self):
         ...
 
-    def test_class_with_methods(self):  # L44-58
+    def test_class_with_methods(self):
         ...
 
-    def test_class_with_attributes_and_methods(self):  # L60-80
+    def test_class_with_attributes_and_methods(self):
         ...
 
-    def test_function_is_none(self):  # L82-89
+    def test_function_is_none(self):
         ...
 
-    def test_class_with_no_members(self):  # L91-102
+    def test_class_with_no_members(self):
         ...
 
-    def test_source_order_preserved(self):  # L104-116
+    def test_source_order_preserved(self):
         ...
 
-    def test_module_level_constants(self):  # L118-131
+    def test_module_level_constants(self):
         ...
 
-    def test_constants_precede_classes_and_functions(self):  # L133-146
+    def test_constants_precede_classes_and_functions(self):
         ...
 
-class TestRenderMap:  # L149-213
+class TestRenderMap:
 
-    def test_roundtrips_through_yaml(self):  # L150-163
+    def test_roundtrips_through_yaml(self):
         ...
 
-    def test_preserves_insertion_order(self):  # L165-174
+    def test_preserves_insertion_order(self):
         ...
 
-    def test_null_renders_clean(self):  # L176-185
+    def test_null_renders_clean(self):
         ...
 
-    def test_header_appears_at_top(self):  # L187-194
+    def test_header_appears_at_top(self):
         ...
 
-    def test_header_mentions_stub_pointer(self):  # L196-200
+    def test_header_mentions_stub_pointer(self):
         ...
 
-    def test_header_does_not_break_yaml_parse(self):  # L202-213
+    def test_header_does_not_break_yaml_parse(self):
         ...

--- a/.uncoded/stubs/tests/test_serena_setup.pyi
+++ b/.uncoded/stubs/tests/test_serena_setup.pyi
@@ -6,69 +6,69 @@ from pathlib import Path
 import yaml
 from uncoded.serena_setup import SERENA_ALLOWED_TOOLS, SERENA_VERSION, read_project_name, setup_serena
 
-REPO_ROOT = Path(__file__).parent.parent  # L14
-EXPECTED_EXCLUDED_TOOLS = ...  # L20-31
+REPO_ROOT = Path(__file__).parent.parent
+EXPECTED_EXCLUDED_TOOLS = ...
 
-class TestReadProjectName:  # L34-52
+class TestReadProjectName:
 
-    def test_reads_name_from_pyproject_toml(self, tmp_path):  # L35-38
+    def test_reads_name_from_pyproject_toml(self, tmp_path):
         ...
 
-    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L40-42
+    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):
         ...
 
-    def test_falls_back_to_cwd_name_when_no_project_section(self, tmp_path):  # L44-47
+    def test_falls_back_to_cwd_name_when_no_project_section(self, tmp_path):
         ...
 
-    def test_falls_back_to_cwd_name_when_name_missing(self, tmp_path):  # L49-52
+    def test_falls_back_to_cwd_name_when_name_missing(self, tmp_path):
         ...
 
-class TestSetupSerena:  # L55-169
+class TestSetupSerena:
 
-    def _run(self, tmp_path, name):  # L56-59
+    def _run(self, tmp_path, name):
         ...
 
-    def test_creates_all_three_files(self, tmp_path):  # L61-65
+    def test_creates_all_three_files(self, tmp_path):
         ...
 
-    def test_mcp_json_is_valid_and_pins_version(self, tmp_path):  # L67-75
+    def test_mcp_json_is_valid_and_pins_version(self, tmp_path):
         ...
 
-    def test_serena_project_yml_uses_ty_and_ignores_uncoded(self, tmp_path):  # L77-84
+    def test_serena_project_yml_uses_ty_and_ignores_uncoded(self, tmp_path):
         ...
 
-    def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):  # L86-91
+    def test_claude_settings_enables_serena_and_allowlists_tools(self, tmp_path):
         ...
 
-    def test_idempotent(self, tmp_path):  # L93-101
+    def test_idempotent(self, tmp_path):
         ...
 
-    def test_merges_into_existing_mcp_json(self, tmp_path):  # L103-111
+    def test_merges_into_existing_mcp_json(self, tmp_path):
         ...
 
-    def test_refreshes_stale_serena_entry_in_mcp_json(self, tmp_path):  # L113-127
+    def test_refreshes_stale_serena_entry_in_mcp_json(self, tmp_path):
         ...
 
-    def test_merges_into_existing_claude_settings(self, tmp_path):  # L129-145
+    def test_merges_into_existing_claude_settings(self, tmp_path):
         ...
 
-    def test_does_not_overwrite_existing_serena_project_yml(self, tmp_path):  # L147-153
+    def test_does_not_overwrite_existing_serena_project_yml(self, tmp_path):
         ...
 
-    def test_does_not_duplicate_on_second_merge(self, tmp_path):  # L155-163
+    def test_does_not_duplicate_on_second_merge(self, tmp_path):
         ...
 
-    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):  # L165-169
+    def test_falls_back_to_cwd_name_when_no_pyproject(self, tmp_path):
         ...
 
-class TestRepoDogfooding:  # L172-199
+class TestRepoDogfooding:
     """Catch drift between setup-serena's templates and this repo's own config."""
 
-    def test_repo_mcp_json_pins_same_serena_version(self):  # L182-185
+    def test_repo_mcp_json_pins_same_serena_version(self):
         ...
 
-    def test_repo_claude_settings_allowlists_every_serena_tool(self):  # L187-193
+    def test_repo_claude_settings_allowlists_every_serena_tool(self):
         ...
 
-    def test_repo_serena_project_yml_matches_template_contract(self):  # L195-199
+    def test_repo_serena_project_yml_matches_template_contract(self):
         ...

--- a/.uncoded/stubs/tests/test_skill.pyi
+++ b/.uncoded/stubs/tests/test_skill.pyi
@@ -4,37 +4,37 @@ import os
 from pathlib import Path
 from uncoded.skill import _SKILL_CONTENT, LEGACY_SKILL_OUTPUTS, SKILL_OUTPUTS, sync_skill
 
-class TestSyncSkill:  # L12-90
+class TestSyncSkill:
 
-    def test_skill_name_and_output_paths(self):  # L13-19
+    def test_skill_name_and_output_paths(self):
         ...
 
-    def test_writes_skill_files(self, tmp_path):  # L21-27
+    def test_writes_skill_files(self, tmp_path):
         ...
 
-    def test_creates_parent_directories(self, tmp_path):  # L29-33
+    def test_creates_parent_directories(self, tmp_path):
         ...
 
-    def test_returns_true_on_first_write(self, tmp_path):  # L35-37
+    def test_returns_true_on_first_write(self, tmp_path):
         ...
 
-    def test_returns_false_when_already_in_sync(self, tmp_path):  # L39-42
+    def test_returns_false_when_already_in_sync(self, tmp_path):
         ...
 
-    def test_idempotent(self, tmp_path):  # L44-51
+    def test_idempotent(self, tmp_path):
         ...
 
-    def test_check_mode_does_not_write(self, tmp_path):  # L53-57
+    def test_check_mode_does_not_write(self, tmp_path):
         ...
 
-    def test_check_mode_reports_change_when_missing(self, tmp_path):  # L59-61
+    def test_check_mode_reports_change_when_missing(self, tmp_path):
         ...
 
-    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):  # L63-66
+    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):
         ...
 
-    def test_removes_legacy_skill_files(self, tmp_path):  # L68-78
+    def test_removes_legacy_skill_files(self, tmp_path):
         ...
 
-    def test_check_mode_reports_legacy_skill_files_without_removing(self, tmp_path):  # L80-90
+    def test_check_mode_reports_legacy_skill_files_without_removing(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -5,192 +5,183 @@ import textwrap
 import pytest
 from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, build_stubs, extract_stub, render_stub
 
-class TestExtractStub:  # L18-322
+class TestExtractStub:
 
-    def test_simple_function(self):  # L19-33
+    def test_simple_function(self):
         ...
 
-    def test_function_no_annotations(self):  # L35-43
+    def test_function_no_annotations(self):
         ...
 
-    def test_async_function(self):  # L45-53
+    def test_async_function(self):
         ...
 
-    def test_private_function_included(self):  # L55-63
+    def test_private_function_included(self):
         ...
 
-    def test_class_with_attributes_and_methods(self):  # L65-92
+    def test_class_with_attributes_and_methods(self):
         ...
 
-    def test_class_line_range(self):  # L94-110
+    def test_class_with_bases(self):
         ...
 
-    def test_class_with_bases(self):  # L112-118
+    def test_class_no_bases(self):
         ...
 
-    def test_class_no_bases(self):  # L120-126
+    def test_docstring_first_sentence_only(self):
         ...
 
-    def test_docstring_first_sentence_only(self):  # L128-135
+    def test_no_docstring(self):
         ...
 
-    def test_no_docstring(self):  # L137-143
+    def test_kwargs_and_varargs(self):
         ...
 
-    def test_kwargs_and_varargs(self):  # L145-153
+    def test_imports_collected(self):
         ...
 
-    def test_imports_collected(self):  # L155-169
+    def test_syntax_error_raises(self):
         ...
 
-    def test_syntax_error_raises(self):  # L171-173
+    def test_source_order_preserved(self):
         ...
 
-    def test_source_order_preserved(self):  # L175-184
+    def test_constant_annotated_with_value(self):
         ...
 
-    def test_constant_annotated_with_value(self):  # L186-196
+    def test_constant_unannotated_with_value(self):
         ...
 
-    def test_constant_unannotated_with_value(self):  # L198-206
+    def test_constant_bare_annotation(self):
         ...
 
-    def test_constant_bare_annotation(self):  # L208-215
+    def test_constant_value_too_long_elided(self):
         ...
 
-    def test_constant_value_too_long_elided(self):  # L217-223
+    def test_constant_private_included(self):
         ...
 
-    def test_constant_private_included(self):  # L225-230
+    def test_type_alias_classic(self):
         ...
 
-    def test_type_alias_classic(self):  # L232-242
+    def test_type_alias_pep695(self):
         ...
 
-    def test_type_alias_pep695(self):  # L244-252
+    def test_tuple_unpacking_skipped(self):
         ...
 
-    def test_tuple_unpacking_skipped(self):  # L254-259
+    def test_class_with_unannotated_attribute(self):
         ...
 
-    def test_class_with_unannotated_attribute(self):  # L261-273
+    def test_property_rendered_as_attribute(self):
         ...
 
-    def test_property_rendered_as_attribute(self):  # L275-290
+    def test_property_without_return_annotation(self):
         ...
 
-    def test_property_without_return_annotation(self):  # L292-302
+    def test_property_setter_and_deleter_suppressed(self):
         ...
 
-    def test_property_setter_and_deleter_suppressed(self):  # L304-322
+class TestRenderStub:
+
+    def test_header_contains_path(self):
         ...
 
-class TestRenderStub:  # L325-548
-
-    def test_header_contains_path(self):  # L326-328
+    def test_imports_rendered(self):
         ...
 
-    def test_imports_rendered(self):  # L330-336
+    def test_rendered_stub_has_no_line_range_comments(self):
         ...
 
-    def test_function_line_range(self):  # L338-344
+    def test_async_function_prefix(self):
         ...
 
-    def test_async_function_prefix(self):  # L346-353
+    def test_function_with_annotations(self):
         ...
 
-    def test_function_with_annotations(self):  # L355-368
+    def test_docstring_excerpt_rendered(self):
         ...
 
-    def test_docstring_excerpt_rendered(self):  # L370-384
+    def test_class_with_bases(self):
         ...
 
-    def test_class_with_bases(self):  # L386-391
+    def test_class_no_bases(self):
         ...
 
-    def test_class_single_line_range(self):  # L393-398
+    def test_attribute_with_annotation(self):
         ...
 
-    def test_function_single_line_range(self):  # L400-405
+    def test_method_indented(self):
         ...
 
-    def test_class_no_bases(self):  # L407-412
+    def test_ends_with_newline(self):
         ...
 
-    def test_attribute_with_annotation(self):  # L414-426
+    def test_property_rendered_as_class_attribute(self):
         ...
 
-    def test_method_indented(self):  # L428-448
+    def test_constant_with_value_rendered(self):
         ...
 
-    def test_ends_with_newline(self):  # L450-452
+    def test_constant_annotated_with_value_rendered(self):
         ...
 
-    def test_property_rendered_as_class_attribute(self):  # L454-468
+    def test_constant_elided_rendered(self):
         ...
 
-    def test_constant_with_value_rendered(self):  # L470-479
+    def test_constant_bare_annotation_rendered(self):
         ...
 
-    def test_constant_annotated_with_value_rendered(self):  # L481-494
+    def test_type_alias_pep695_rendered(self):
         ...
 
-    def test_constant_elided_rendered(self):  # L496-505
+    def test_unannotated_class_attribute_rendered(self):
         ...
 
-    def test_constant_bare_annotation_rendered(self):  # L507-516
-        ...
-
-    def test_type_alias_pep695_rendered(self):  # L518-531
-        ...
-
-    def test_unannotated_class_attribute_rendered(self):  # L533-548
-        ...
-
-class TestBuildStubs:  # L551-639
+class TestBuildStubs:
     """build_stubs writes expected stubs and removes orphans for its source root."""
 
-    def _setup(self, tmp_path):  # L554-559
+    def _setup(self, tmp_path):
         ...
 
-    def test_writes_expected_stubs(self, tmp_path):  # L561-565
+    def test_writes_expected_stubs(self, tmp_path):
         ...
 
-    def test_removes_orphan_stub_when_source_deleted(self, tmp_path):  # L567-577
+    def test_removes_orphan_stub_when_source_deleted(self, tmp_path):
         ...
 
-    def test_removes_orphan_stub_when_source_renamed(self, tmp_path):  # L579-588
+    def test_removes_orphan_stub_when_source_renamed(self, tmp_path):
         ...
 
-    def test_prunes_empty_directories(self, tmp_path):  # L590-602
+    def test_prunes_empty_directories(self, tmp_path):
         ...
 
-    def test_does_not_touch_other_source_root(self, tmp_path):  # L604-618
+    def test_does_not_touch_other_source_root(self, tmp_path):
         ...
 
-    def test_no_op_when_clean(self, tmp_path):  # L620-627
+    def test_no_op_when_clean(self, tmp_path):
         ...
 
-    def test_reports_count_on_first_build(self, tmp_path):  # L629-633
+    def test_reports_count_on_first_build(self, tmp_path):
         ...
 
-    def test_reports_zero_when_clean(self, tmp_path):  # L635-639
+    def test_reports_zero_when_clean(self, tmp_path):
         ...
 
-class TestBuildStubsCheckMode:  # L642-681
+class TestBuildStubsCheckMode:
     """build_stubs with check=True must report changes without mutating the tree."""
 
-    def _setup(self, tmp_path):  # L645-650
+    def _setup(self, tmp_path):
         ...
 
-    def test_does_not_write_stub_in_check_mode(self, tmp_path):  # L652-657
+    def test_does_not_write_stub_in_check_mode(self, tmp_path):
         ...
 
-    def test_zero_changes_when_clean(self, tmp_path):  # L659-663
+    def test_zero_changes_when_clean(self, tmp_path):
         ...
 
-    def test_detects_stale_stub_content(self, tmp_path):  # L665-671
+    def test_detects_stale_stub_content(self, tmp_path):
         ...
 
-    def test_detects_orphan_stub_without_removing_it(self, tmp_path):  # L673-681
+    def test_detects_orphan_stub_without_removing_it(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_sync.pyi
+++ b/.uncoded/stubs/tests/test_sync.pyi
@@ -2,42 +2,42 @@
 
 from uncoded.sync import remove_file, sync_file
 
-class TestSyncFile:  # L4-56
+class TestSyncFile:
 
-    def test_creates_missing_file(self, tmp_path):  # L5-9
+    def test_creates_missing_file(self, tmp_path):
         ...
 
-    def test_creates_parent_directories(self, tmp_path):  # L11-15
+    def test_creates_parent_directories(self, tmp_path):
         ...
 
-    def test_updates_when_content_differs(self, tmp_path):  # L17-22
+    def test_updates_when_content_differs(self, tmp_path):
         ...
 
-    def test_noop_when_content_matches(self, tmp_path):  # L24-31
+    def test_noop_when_content_matches(self, tmp_path):
         ...
 
-    def test_check_mode_does_not_create_file(self, tmp_path):  # L33-37
+    def test_check_mode_does_not_create_file(self, tmp_path):
         ...
 
-    def test_check_mode_does_not_update_file(self, tmp_path):  # L39-44
+    def test_check_mode_does_not_update_file(self, tmp_path):
         ...
 
-    def test_check_mode_reports_noop_when_clean(self, tmp_path):  # L46-50
+    def test_check_mode_reports_noop_when_clean(self, tmp_path):
         ...
 
-    def test_check_mode_does_not_create_parent_directories(self, tmp_path):  # L52-56
+    def test_check_mode_does_not_create_parent_directories(self, tmp_path):
         ...
 
-class TestRemoveFile:  # L59-82
+class TestRemoveFile:
 
-    def test_removes_existing_file(self, tmp_path):  # L60-65
+    def test_removes_existing_file(self, tmp_path):
         ...
 
-    def test_noop_when_absent(self, tmp_path):  # L67-70
+    def test_noop_when_absent(self, tmp_path):
         ...
 
-    def test_check_mode_does_not_remove(self, tmp_path):  # L72-77
+    def test_check_mode_does_not_remove(self, tmp_path):
         ...
 
-    def test_check_mode_reports_noop_when_absent(self, tmp_path):  # L79-82
+    def test_check_mode_reports_noop_when_absent(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_uncoded.pyi
+++ b/.uncoded/stubs/tests/test_uncoded.pyi
@@ -2,8 +2,8 @@
 
 import uncoded
 
-def test_import():  # L4-5
+def test_import():
     ...
 
-def test_version_is_exposed():  # L8-10
+def test_version_is_exposed():
     ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Two-level index:
 
 2. **Stub files** (`.uncoded/stubs/`) — one `.pyi` per source file, with
    imports, full signatures (parameter names, types, return types),
-   first-sentence docstrings, and `L<start>-<end>` line range comments.
+   first-sentence docstrings, module constants, and class attributes.
 
 ## Commands
 
@@ -76,36 +76,31 @@ tests/test_foo.py   →  .uncoded/stubs/tests/test_foo.pyi
 
 This applies to every file you intend to touch or reference — including
 tests. The stub is sufficient for most navigation: it contains imports,
-every signature with types, first-sentence docstrings, and a `L<start>`
-or `L<start>-<end>` line range on every definition. Skipping to source
-means reading many lines to learn what the stub would have told you in
-one. If no stub exists at the expected path, the file has no symbols
-indexed — in that narrow case, read source directly.
+every signature with types, module-level assignments, class attributes,
+and first-sentence docstrings. Skipping to source means reading many
+lines to learn what the stub would have told you in one. If no stub
+exists at the expected path, the file has no symbols indexed — in that
+narrow case, read source directly.
 
-**Step 3 — Read source, never without offset and limit.** When you need
-source beyond what the stub shows, use the stub's line range:
+**Step 3 — Read source through Serena.** When you need source beyond
+what the stub shows, use Serena to read exactly the symbol body. The
+namespace map and stub give you the exact `relative_path` and `name_path`
+Serena needs — e.g. `ClassName/method` for a method,
+`function_name` for a top-level function.
 
-```
-Read src/foo/bar.py  offset=<start>  limit=<end - start + 1>
-```
-
-Calling Read on a `.py` file without `offset` and `limit` is a protocol
-violation — it means either Step 2 was skipped, or you are reading more
-of the file than the stub said you needed. The one exception is the
-first Read of a stub-less file (see Step 2), which is genuinely
-exploratory.
+Stubs intentionally do not carry source line ranges: line numbers churn
+when nearby code moves, creating noisy generated diffs and teaching
+agents to trust stale coordinates. Let uncoded provide the stable map
+and signatures; let Serena resolve the current source body.
 
 **For symbol-level operations — use Serena.** Where Serena's MCP tools
 are available (`mcp__serena__*` in the tool list), prefer them over
 Read / Edit / grep for anything that operates on a symbol as a unit.
-The namespace map gives you the exact `name_path` and `relative_path`
-these tools take as input — e.g. `ClassName/method` for a method,
-`function_name` for a top-level function.
 
 - **Read one symbol body.** `find_symbol` with `include_body=True`
-  returns exactly the symbol — no `offset` / `limit` arithmetic, no
-  risk of reading too much. Often easier than the Step 3 dance for a
-  single function or method. (Stay on stubs for a wider sweep.)
+  returns exactly the symbol — no offset arithmetic, no risk of reading
+  too much. Stay on stubs for a wider sweep; use Serena when you need
+  implementation detail.
 - **Find callers, or check whether a symbol is dead.**
   `find_referencing_symbols` returns every reference resolved by the
   language server. Do not grep for the name — grep hits comments,
@@ -123,7 +118,7 @@ these tools take as input — e.g. `ClassName/method` for a method,
   stays put.
 
 Reach for Read + Edit when Serena does not fit: free-text files
-(Markdown, YAML, configs), partial-line edits inside a function
-body, or the rare stub-less Python file that needs exploratory
-reading.
+(Markdown, YAML, configs), partial-line edits inside a function body
+after you have retrieved it, environments where Serena is unavailable,
+or the rare stub-less Python file that needs exploratory reading.
 <!-- uncoded:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Two-level index:
 
 2. **Stub files** (`.uncoded/stubs/`) — one `.pyi` per source file, with
    imports, full signatures (parameter names, types, return types),
-   first-sentence docstrings, and `L<start>-<end>` line range comments.
+   first-sentence docstrings, module constants, and class attributes.
 
 ## Commands
 
@@ -76,36 +76,31 @@ tests/test_foo.py   →  .uncoded/stubs/tests/test_foo.pyi
 
 This applies to every file you intend to touch or reference — including
 tests. The stub is sufficient for most navigation: it contains imports,
-every signature with types, first-sentence docstrings, and a `L<start>`
-or `L<start>-<end>` line range on every definition. Skipping to source
-means reading many lines to learn what the stub would have told you in
-one. If no stub exists at the expected path, the file has no symbols
-indexed — in that narrow case, read source directly.
+every signature with types, module-level assignments, class attributes,
+and first-sentence docstrings. Skipping to source means reading many
+lines to learn what the stub would have told you in one. If no stub
+exists at the expected path, the file has no symbols indexed — in that
+narrow case, read source directly.
 
-**Step 3 — Read source, never without offset and limit.** When you need
-source beyond what the stub shows, use the stub's line range:
+**Step 3 — Read source through Serena.** When you need source beyond
+what the stub shows, use Serena to read exactly the symbol body. The
+namespace map and stub give you the exact `relative_path` and `name_path`
+Serena needs — e.g. `ClassName/method` for a method,
+`function_name` for a top-level function.
 
-```
-Read src/foo/bar.py  offset=<start>  limit=<end - start + 1>
-```
-
-Calling Read on a `.py` file without `offset` and `limit` is a protocol
-violation — it means either Step 2 was skipped, or you are reading more
-of the file than the stub said you needed. The one exception is the
-first Read of a stub-less file (see Step 2), which is genuinely
-exploratory.
+Stubs intentionally do not carry source line ranges: line numbers churn
+when nearby code moves, creating noisy generated diffs and teaching
+agents to trust stale coordinates. Let uncoded provide the stable map
+and signatures; let Serena resolve the current source body.
 
 **For symbol-level operations — use Serena.** Where Serena's MCP tools
 are available (`mcp__serena__*` in the tool list), prefer them over
 Read / Edit / grep for anything that operates on a symbol as a unit.
-The namespace map gives you the exact `name_path` and `relative_path`
-these tools take as input — e.g. `ClassName/method` for a method,
-`function_name` for a top-level function.
 
 - **Read one symbol body.** `find_symbol` with `include_body=True`
-  returns exactly the symbol — no `offset` / `limit` arithmetic, no
-  risk of reading too much. Often easier than the Step 3 dance for a
-  single function or method. (Stay on stubs for a wider sweep.)
+  returns exactly the symbol — no offset arithmetic, no risk of reading
+  too much. Stay on stubs for a wider sweep; use Serena when you need
+  implementation detail.
 - **Find callers, or check whether a symbol is dead.**
   `find_referencing_symbols` returns every reference resolved by the
   language server. Do not grep for the name — grep hits comments,
@@ -123,7 +118,7 @@ these tools take as input — e.g. `ClassName/method` for a method,
   stays put.
 
 Reach for Read + Edit when Serena does not fit: free-text files
-(Markdown, YAML, configs), partial-line edits inside a function
-body, or the rare stub-less Python file that needs exploratory
-reading.
+(Markdown, YAML, configs), partial-line edits inside a function body
+after you have retrieved it, environments where Serena is unavailable,
+or the rare stub-less Python file that needs exploratory reading.
 <!-- uncoded:end -->

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and immediately know the full vocabulary of the codebase.
 
 **`.uncoded/stubs/`** — one `.pyi` stub per source file, with imports, full
 signatures (parameter names, types, return types), first-sentence docstrings,
-and an `L<start>-<end>` line range on every definition.
+module constants, and class attributes.
 
 **`.claude/skills/coherence-review/SKILL.md`** and
 **`.agents/skills/coherence-review/SKILL.md`** — a coherence review skill,
@@ -97,19 +97,22 @@ uncoded check
 It runs the same pipeline but writes nothing. Exits 0 if every generated
 file is byte-identical to what a rebuild would produce, and 1 otherwise
 — printing which files would change. A stale index is a silent failure
-mode (agents read misleading line ranges and signatures), so gating on
-this in CI is worthwhile even alongside a pre-commit hook.
+mode (agents read misleading names and signatures), so gating on this in
+CI is worthwhile even alongside a pre-commit hook.
 
 ## How agents use it
 
 When `uncoded` is set up, a navigation section is automatically maintained in
-`CLAUDE.md`. Agents following that protocol:
+the configured instruction files (by default, `CLAUDE.md` and `AGENTS.md`).
+Agents following that protocol:
 
 1. Read `.uncoded/namespace.yaml` to orient — every symbol, at a glance.
-2. Read the relevant `.pyi` stubs to understand signatures and locate line ranges.
-3. Read only the source lines they need, using the `L<start>-<end>` ranges from the stubs.
+2. Read the relevant `.pyi` stubs to understand imports, signatures, constants, class members, and docstring summaries.
+3. Use Serena's `find_symbol(..., include_body=True)` when they need implementation detail for a specific symbol.
 
-Three reads to navigate to any symbol in the codebase. No grep.
+The split is deliberate: `uncoded` provides a stable map and semantic summary;
+Serena resolves the current source body. No grep, no stale line-number
+coordinates, no offset arithmetic.
 
 ## Coherence review
 

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -52,36 +52,31 @@ tests/test_foo.py   →  .uncoded/stubs/tests/test_foo.pyi
 
 This applies to every file you intend to touch or reference — including
 tests. The stub is sufficient for most navigation: it contains imports,
-every signature with types, first-sentence docstrings, and a `L<start>`
-or `L<start>-<end>` line range on every definition. Skipping to source
-means reading many lines to learn what the stub would have told you in
-one. If no stub exists at the expected path, the file has no symbols
-indexed — in that narrow case, read source directly.
+every signature with types, module-level assignments, class attributes,
+and first-sentence docstrings. Skipping to source means reading many
+lines to learn what the stub would have told you in one. If no stub
+exists at the expected path, the file has no symbols indexed — in that
+narrow case, read source directly.
 
-**Step 3 — Read source, never without offset and limit.** When you need
-source beyond what the stub shows, use the stub's line range:
+**Step 3 — Read source through Serena.** When you need source beyond
+what the stub shows, use Serena to read exactly the symbol body. The
+namespace map and stub give you the exact `relative_path` and `name_path`
+Serena needs — e.g. `ClassName/method` for a method,
+`function_name` for a top-level function.
 
-```
-Read src/foo/bar.py  offset=<start>  limit=<end - start + 1>
-```
-
-Calling Read on a `.py` file without `offset` and `limit` is a protocol
-violation — it means either Step 2 was skipped, or you are reading more
-of the file than the stub said you needed. The one exception is the
-first Read of a stub-less file (see Step 2), which is genuinely
-exploratory.
+Stubs intentionally do not carry source line ranges: line numbers churn
+when nearby code moves, creating noisy generated diffs and teaching
+agents to trust stale coordinates. Let uncoded provide the stable map
+and signatures; let Serena resolve the current source body.
 
 **For symbol-level operations — use Serena.** Where Serena's MCP tools
 are available (`mcp__serena__*` in the tool list), prefer them over
 Read / Edit / grep for anything that operates on a symbol as a unit.
-The namespace map gives you the exact `name_path` and `relative_path`
-these tools take as input — e.g. `ClassName/method` for a method,
-`function_name` for a top-level function.
 
 - **Read one symbol body.** `find_symbol` with `include_body=True`
-  returns exactly the symbol — no `offset` / `limit` arithmetic, no
-  risk of reading too much. Often easier than the Step 3 dance for a
-  single function or method. (Stay on stubs for a wider sweep.)
+  returns exactly the symbol — no offset arithmetic, no risk of reading
+  too much. Stay on stubs for a wider sweep; use Serena when you need
+  implementation detail.
 - **Find callers, or check whether a symbol is dead.**
   `find_referencing_symbols` returns every reference resolved by the
   language server. Do not grep for the name — grep hits comments,
@@ -99,9 +94,9 @@ these tools take as input — e.g. `ClassName/method` for a method,
   stays put.
 
 Reach for Read + Edit when Serena does not fit: free-text files
-(Markdown, YAML, configs), partial-line edits inside a function
-body, or the rare stub-less Python file that needs exploratory
-reading."""
+(Markdown, YAML, configs), partial-line edits inside a function body
+after you have retrieved it, environments where Serena is unavailable,
+or the rare stub-less Python file that needs exploratory reading."""
 
 SECTION = f"{MARKER_START}\n{_SECTION_BODY}\n{MARKER_END}\n"
 

--- a/src/uncoded/namespace_map.py
+++ b/src/uncoded/namespace_map.py
@@ -14,7 +14,7 @@ HEADER = """\
 # Directory keys end with "/". Entries within a file or class appear
 # in source order.
 #
-# For signatures, types, and line ranges, see stubs:
+# For signatures and types, see stubs:
 #   src/foo/bar.py  →  .uncoded/stubs/src/foo/bar.pyi
 """
 

--- a/src/uncoded/skill.py
+++ b/src/uncoded/skill.py
@@ -222,10 +222,10 @@ Check systematically, not by spot-check:
 **Redundant public surface.** A public constant and a public parameterless
 function in the same module where the function's sole body is `return
 <constant>`. Both symbols being public exposes an implementation detail
-unnecessarily — only one needs to be public. Detection: look for parameterless
-public functions with a trivial single-line body (visible from the stub's line
-range), then verify the body with Serena's `find_symbol` with
-`include_body=True` before reporting.
+unnecessarily — only one needs to be public. Detection: use the stubs to find
+public parameterless functions near public constants, then verify each
+candidate body with Serena's `find_symbol` with `include_body=True` before
+reporting.
 
 ## Report format
 
@@ -261,7 +261,7 @@ Regions with two or more findings — examine these first:
   collision-with-drift | name-signature-mismatch | docstring-signature-mismatch |
   docstring-name-mismatch | defensive-docstring | god-module |
   boundary-violation | cross-vocabulary-import | zero-caller
-**Location:** `path/to/file.py` · `ClassName/method_name` · L12–L34
+**Location:** `path/to/file.py` · `ClassName/method_name`
 **Confidence:** high | medium | low
 
 **Evidence:**

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -9,7 +9,7 @@ from uncoded.extract import _property_kind, iter_source_files
 from uncoded.sync import remove_file, sync_file
 
 # Width cap for inlining the right-hand side of an assignment. If the unparsed
-# RHS exceeds this, it is elided to "..." and the reader follows the line range.
+# RHS exceeds this, it is elided to "..." so stubs stay compact and stable.
 VALUE_WIDTH_CAP = 80
 
 
@@ -23,14 +23,12 @@ class StubParam:
 
 @dataclass
 class StubFunction:
-    """A function or method with its signature and line range."""
+    """A function or method with its signature."""
 
     name: str
     params: list[StubParam] = field(default_factory=list)
     return_annotation: str | None = None
     docstring_excerpt: str | None = None
-    start_line: int = 0
-    end_line: int = 0
     is_async: bool = False
 
 
@@ -46,20 +44,16 @@ class StubAssignment:
     name: str
     annotation: str | None = None
     value_source: str | None = None
-    start_line: int = 0
-    end_line: int = 0
     is_type_alias: bool = False
 
 
 @dataclass
 class StubClass:
-    """A class with its members and line range."""
+    """A class with its members."""
 
     name: str
     bases: list[str] = field(default_factory=list)
     docstring_excerpt: str | None = None
-    start_line: int = 0
-    end_line: int = 0
     attributes: list[StubAssignment] = field(default_factory=list)
     methods: list[StubFunction] = field(default_factory=list)
 
@@ -124,11 +118,6 @@ def _extract_params(args: ast.arguments) -> list[StubParam]:
     return params
 
 
-def _line_range(start: int, end: int) -> str:
-    """Render a line range: 'L<start>' if single-line, else 'L<start>-<end>'."""
-    return f"L{start}" if start == end else f"L{start}-{end}"
-
-
 def _render_value(value: ast.expr) -> str:
     """Render an expression as source, eliding to '...' if too long or multi-line."""
     source = ast.unparse(value)
@@ -145,17 +134,12 @@ def _extract_assignment(
     Returns None if the node's target is not a single simple name (e.g. tuple
     unpacking or attribute assignment), which we can't represent cleanly.
     """
-    start_line = node.lineno
-    end_line = node.end_lineno or node.lineno
-
     if isinstance(node, ast.TypeAlias):
         if not isinstance(node.name, ast.Name):
             return None
         return StubAssignment(
             name=node.name.id,
             value_source=_render_value(node.value),
-            start_line=start_line,
-            end_line=end_line,
             is_type_alias=True,
         )
 
@@ -168,8 +152,6 @@ def _extract_assignment(
             name=node.target.id,
             annotation=annotation,
             value_source=value_source,
-            start_line=start_line,
-            end_line=end_line,
         )
 
     # ast.Assign
@@ -178,8 +160,6 @@ def _extract_assignment(
     return StubAssignment(
         name=node.targets[0].id,
         value_source=_render_value(node.value),
-        start_line=start_line,
-        end_line=end_line,
     )
 
 
@@ -192,8 +172,6 @@ def _extract_function(
         params=_extract_params(node.args),
         return_annotation=ast.unparse(node.returns) if node.returns else None,
         docstring_excerpt=_first_sentence(node),
-        start_line=node.lineno,
-        end_line=node.end_lineno or node.lineno,
         is_async=isinstance(node, ast.AsyncFunctionDef),
     )
 
@@ -206,8 +184,6 @@ def _property_attribute(
         name=node.name,
         annotation=ast.unparse(node.returns) if node.returns else None,
         value_source=None,
-        start_line=node.lineno,
-        end_line=node.end_lineno or node.lineno,
         is_type_alias=False,
     )
 
@@ -237,15 +213,13 @@ def _extract_class(node: ast.ClassDef) -> StubClass:
         name=node.name,
         bases=bases,
         docstring_excerpt=_first_sentence(node),
-        start_line=node.lineno,
-        end_line=node.end_lineno or node.lineno,
         attributes=attributes,
         methods=methods,
     )
 
 
 def extract_stub(source: str, rel_path: str) -> StubModule:
-    """Parse Python source and extract all symbols with signatures and line ranges."""
+    """Parse Python source and extract all symbols with signatures."""
     tree = ast.parse(source)
     imports: list[str] = []
     constants: list[StubAssignment] = []
@@ -287,9 +261,7 @@ def _render_function(func: StubFunction, indent: str = "") -> list[str]:
     params_str = ", ".join(_render_param(p) for p in func.params)
     ret = f" -> {func.return_annotation}" if func.return_annotation else ""
     prefix = "async def" if func.is_async else "def"
-    lines = [
-        f"{indent}{prefix} {func.name}({params_str}){ret}:  # {_line_range(func.start_line, func.end_line)}"  # noqa: E501
-    ]
+    lines = [f"{indent}{prefix} {func.name}({params_str}){ret}:"]
     if func.docstring_excerpt:
         lines.append(f'{indent}    """{func.docstring_excerpt}"""')
     lines.append(f"{indent}    ...")
@@ -307,13 +279,13 @@ def _format_assignment_body(a: StubAssignment) -> str:
 
 
 def _render_assignment(a: StubAssignment, indent: str = "") -> str:
-    """Render a module-level assignment as a stub line, with line range."""
+    """Render a module-level assignment as a stub line."""
     body = _format_assignment_body(a)
-    return f"{indent}{body}  # {_line_range(a.start_line, a.end_line)}"
+    return f"{indent}{body}"
 
 
 def _render_class_attribute(a: StubAssignment, indent: str = "    ") -> str:
-    """Render a class attribute as a stub line (no line range — class has one)."""
+    """Render a class attribute as a stub line."""
     return f"{indent}{_format_assignment_body(a)}"
 
 
@@ -336,8 +308,7 @@ def render_stub(module: StubModule) -> str:
 
     for cls in module.classes:
         bases_str = f"({', '.join(cls.bases)})" if cls.bases else ""
-        range_str = _line_range(cls.start_line, cls.end_line)
-        lines.append(f"class {cls.name}{bases_str}:  # {range_str}")
+        lines.append(f"class {cls.name}{bases_str}:")
         if cls.docstring_excerpt:
             lines.append(f'    """{cls.docstring_excerpt}"""')
         lines.append("")

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -219,7 +219,7 @@ def _extract_class(node: ast.ClassDef) -> StubClass:
 
 
 def extract_stub(source: str, rel_path: str) -> StubModule:
-    """Parse Python source and extract all symbols with signatures."""
+    """Parse Python source and extract imports, constants, classes, and functions."""
     tree = ast.parse(source)
     imports: list[str] = []
     constants: list[StubAssignment] = []
@@ -284,11 +284,6 @@ def _render_assignment(a: StubAssignment, indent: str = "") -> str:
     return f"{indent}{body}"
 
 
-def _render_class_attribute(a: StubAssignment, indent: str = "    ") -> str:
-    """Render a class attribute as a stub line."""
-    return f"{indent}{_format_assignment_body(a)}"
-
-
 def render_stub(module: StubModule) -> str:
     """Render a StubModule as a .pyi file string."""
     lines: list[str] = [f"# {module.rel_path}", ""]
@@ -314,7 +309,7 @@ def render_stub(module: StubModule) -> str:
         lines.append("")
 
         for attr in cls.attributes:
-            lines.append(_render_class_attribute(attr))
+            lines.append(_render_assignment(attr, indent="    "))
         if cls.attributes:
             lines.append("")
 

--- a/tests/test_namespace_map.py
+++ b/tests/test_namespace_map.py
@@ -195,7 +195,7 @@ class TestRenderMap:
 
     def test_header_mentions_stub_pointer(self):
         # The header's job is partly to tell a cold-start agent where to find
-        # signatures, types, and line ranges. Lock in that pointer.
+        # signatures and types. Lock in that pointer.
         output = render_map(build_map([]))
         assert ".uncoded/stubs/" in output
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -29,8 +29,6 @@ class TestExtractStub:
         assert f.params == [StubParam("name", "str")]
         assert f.return_annotation == "str"
         assert f.docstring_excerpt == "Say hello."
-        assert f.start_line == 1
-        assert f.end_line == 3
 
     def test_function_no_annotations(self):
         source = textwrap.dedent("""\
@@ -90,24 +88,6 @@ class TestExtractStub:
         assert len(cls.methods) == 2
         assert cls.methods[0].name == "save"
         assert cls.methods[1].name == "_validate"
-
-    def test_class_line_range(self):
-        source = textwrap.dedent("""\
-            class Foo:
-                def bar(self):
-                    pass
-
-                def baz(self):
-                    pass
-        """)
-        module = extract_stub(source, "pkg/foo.py")
-        cls = module.classes[0]
-        assert cls.start_line == 1
-        assert cls.end_line == 6
-        assert cls.methods[0].start_line == 2
-        assert cls.methods[0].end_line == 3
-        assert cls.methods[1].start_line == 5
-        assert cls.methods[1].end_line == 6
 
     def test_class_with_bases(self):
         source = textwrap.dedent("""\
@@ -193,7 +173,6 @@ class TestExtractStub:
         assert c.annotation == "int"
         assert c.value_source == "3"
         assert c.is_type_alias is False
-        assert c.start_line == 1
 
     def test_constant_unannotated_with_value(self):
         source = textwrap.dedent("""\
@@ -335,20 +314,34 @@ class TestRenderStub:
         output = render_stub(module)
         assert "import os\nfrom pathlib import Path" in output
 
-    def test_function_line_range(self):
+    def test_rendered_stub_has_no_line_range_comments(self):
         module = StubModule(
             rel_path="pkg/mod.py",
-            functions=[StubFunction(name="run", start_line=10, end_line=20)],
+            constants=[StubAssignment(name="VALUE", value_source="1")],
+            functions=[StubFunction(name="run")],
+            classes=[
+                StubClass(
+                    name="Worker",
+                    methods=[
+                        StubFunction(
+                            name="work",
+                            params=[StubParam("self")],
+                        )
+                    ],
+                )
+            ],
         )
         output = render_stub(module)
-        assert "def run():  # L10-20\n    ..." in output
+        assert "VALUE = 1" in output
+        assert "def run():\n    ..." in output
+        assert "class Worker:" in output
+        assert "    def work(self):" in output
+        assert "# L" not in output
 
     def test_async_function_prefix(self):
         module = StubModule(
             rel_path="pkg/mod.py",
-            functions=[
-                StubFunction(name="fetch", is_async=True, start_line=1, end_line=3)
-            ],
+            functions=[StubFunction(name="fetch", is_async=True)],
         )
         assert "async def fetch" in render_stub(module)
 
@@ -360,8 +353,6 @@ class TestRenderStub:
                     name="greet",
                     params=[StubParam("name", "str")],
                     return_annotation="str",
-                    start_line=1,
-                    end_line=2,
                 )
             ],
         )
@@ -374,8 +365,6 @@ class TestRenderStub:
                 StubFunction(
                     name="go",
                     docstring_excerpt="Do the thing.",
-                    start_line=1,
-                    end_line=3,
                 )
             ],
         )
@@ -386,30 +375,16 @@ class TestRenderStub:
     def test_class_with_bases(self):
         module = StubModule(
             rel_path="pkg/mod.py",
-            classes=[StubClass(name="Dog", bases=["Animal"], start_line=1, end_line=5)],
+            classes=[StubClass(name="Dog", bases=["Animal"])],
         )
-        assert "class Dog(Animal):  # L1-5" in render_stub(module)
-
-    def test_class_single_line_range(self):
-        module = StubModule(
-            rel_path="pkg/mod.py",
-            classes=[StubClass(name="Marker", start_line=7, end_line=7)],
-        )
-        assert "class Marker:  # L7\n" in render_stub(module)
-
-    def test_function_single_line_range(self):
-        module = StubModule(
-            rel_path="pkg/mod.py",
-            functions=[StubFunction(name="noop", start_line=3, end_line=3)],
-        )
-        assert "def noop():  # L3\n" in render_stub(module)
+        assert "class Dog(Animal):" in render_stub(module)
 
     def test_class_no_bases(self):
         module = StubModule(
             rel_path="pkg/mod.py",
-            classes=[StubClass(name="Plain", start_line=1, end_line=2)],
+            classes=[StubClass(name="Plain")],
         )
-        assert "class Plain:  # L1-2" in render_stub(module)
+        assert "class Plain:" in render_stub(module)
 
     def test_attribute_with_annotation(self):
         module = StubModule(
@@ -417,8 +392,6 @@ class TestRenderStub:
             classes=[
                 StubClass(
                     name="Record",
-                    start_line=1,
-                    end_line=3,
                     attributes=[StubAssignment("name", annotation="str")],
                 )
             ],
@@ -431,21 +404,17 @@ class TestRenderStub:
             classes=[
                 StubClass(
                     name="Foo",
-                    start_line=1,
-                    end_line=5,
                     methods=[
                         StubFunction(
                             name="bar",
                             params=[StubParam("self")],
-                            start_line=2,
-                            end_line=4,
                         )
                     ],
                 )
             ],
         )
         output = render_stub(module)
-        assert "    def bar(self):  # L2-4" in output
+        assert "    def bar(self):" in output
 
     def test_ends_with_newline(self):
         module = StubModule(rel_path="pkg/mod.py")
@@ -470,13 +439,9 @@ class TestRenderStub:
     def test_constant_with_value_rendered(self):
         module = StubModule(
             rel_path="pkg/mod.py",
-            constants=[
-                StubAssignment(
-                    name="TIMEOUT", value_source="30", start_line=3, end_line=3
-                )
-            ],
+            constants=[StubAssignment(name="TIMEOUT", value_source="30")],
         )
-        assert "TIMEOUT = 30  # L3" in render_stub(module)
+        assert "TIMEOUT = 30" in render_stub(module)
 
     def test_constant_annotated_with_value_rendered(self):
         module = StubModule(
@@ -486,33 +451,25 @@ class TestRenderStub:
                     name="MAX",
                     annotation="int",
                     value_source="3",
-                    start_line=4,
-                    end_line=4,
                 )
             ],
         )
-        assert "MAX: int = 3  # L4" in render_stub(module)
+        assert "MAX: int = 3" in render_stub(module)
 
     def test_constant_elided_rendered(self):
         module = StubModule(
             rel_path="pkg/mod.py",
-            constants=[
-                StubAssignment(
-                    name="BIG", value_source="...", start_line=5, end_line=10
-                )
-            ],
+            constants=[StubAssignment(name="BIG", value_source="...")],
         )
-        assert "BIG = ...  # L5-10" in render_stub(module)
+        assert "BIG = ..." in render_stub(module)
 
     def test_constant_bare_annotation_rendered(self):
         module = StubModule(
             rel_path="pkg/mod.py",
-            constants=[
-                StubAssignment(name="FOO", annotation="int", start_line=2, end_line=2)
-            ],
+            constants=[StubAssignment(name="FOO", annotation="int")],
         )
         output = render_stub(module)
-        assert "FOO: int  # L2" in output
+        assert "FOO: int" in output
         assert "FOO: int = " not in output
 
     def test_type_alias_pep695_rendered(self):
@@ -523,12 +480,10 @@ class TestRenderStub:
                     name="UserId",
                     value_source="int",
                     is_type_alias=True,
-                    start_line=1,
-                    end_line=1,
                 )
             ],
         )
-        assert "type UserId = int  # L1" in render_stub(module)
+        assert "type UserId = int" in render_stub(module)
 
     def test_unannotated_class_attribute_rendered(self):
         module = StubModule(
@@ -536,16 +491,13 @@ class TestRenderStub:
             classes=[
                 StubClass(
                     name="Registry",
-                    start_line=1,
-                    end_line=3,
                     attributes=[StubAssignment("items", value_source="[]")],
                 )
             ],
         )
         output = render_stub(module)
         assert "    items = []" in output
-        # No line range comment on class attributes.
-        assert "items = []  # L" not in output
+        assert "# L" not in output
 
 
 class TestBuildStubs:


### PR DESCRIPTION
## Summary

- Remove source line ranges from the stub data model and generated .pyi files.
- Update agent navigation guidance to use stable uncoded stubs for overview and Serena find_symbol(..., include_body=True) for current source bodies.
- Refresh README, AGENTS/CLAUDE generated sections, coherence-review skill text, namespace map, generated stubs, and tests.

## Why

Stub line comments changed whenever nearby source moved, creating generated diff noise and preserving a stale-coordinate navigation contract. This keeps stubs as stable semantic summaries and leaves exact source-body resolution to Serena.

Closes #35.

## Validation

- uv run pytest
- uv run uncoded check
- git diff --check
