### PR TITLE
[codex] Auto publish GitHub releases to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
+      - run: uv build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  pypi-publish:
+    name: Publish distributions to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/uncoded
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,6 +1,26 @@
 # Maintenance notes
 
-Things noticed but not fixed — kept here so the next maintainer can
-weigh them deliberately rather than rediscover them by surprise.
+## Release publishing
+
+GitHub releases publish to PyPI through `.github/workflows/publish.yml`.
+The workflow uses PyPI Trusted Publishing, so it does not need a `PYPI_TOKEN`
+or any other long-lived publishing secret.
+
+The PyPI trusted publisher is configured for:
+
+- PyPI project: `uncoded`
+- Owner: `alimanfoo`
+- Repository: `uncoded`
+- Workflow: `publish.yml`
+- Environment: `pypi`
+
+To release, create and publish a GitHub release from the release tag. The
+`published` release event builds the source distribution and wheel, then
+uploads them to PyPI.
+
+## Deferred work
+
+Things noticed but not fixed — kept here so the next maintainer can weigh them
+deliberately rather than rediscover them by surprise.
 
 Nothing currently deferred.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ working in the repo pick up the instructions automatically.
 ## Install
 
 ```
-pip install git+https://github.com/alimanfoo/uncoded
+pip install uncoded
 ```
 
 Or with uv:
 
 ```
-uv add git+https://github.com/alimanfoo/uncoded
+uv add uncoded
 ```
 
 ## Configure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "uncoded"
 dynamic = ["version"]
-description = "Here be dragons."
+description = "Static symbol indexes for AI-assisted code navigation"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
## Summary

- Add a release-triggered GitHub Actions workflow that builds distributions and publishes them to PyPI with Trusted Publishing.
- Document the configured PyPI trusted publisher details and release path in MAINTENANCE.md.
- Update install instructions and package metadata now that releases are intended to be available from PyPI.

Fixes #32.

## Notes

The PyPI trusted publisher is already configured for alimanfoo/uncoded, workflow publish.yml, environment pypi, so no PYPI_TOKEN secret is needed.

## Validation

- uv build
- uv run pytest
- uv run pre-commit run --all-files