### PR TITLE
[claude] cli._sync working-directory contract + post-#76 cleanup

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -35,6 +35,7 @@ src/:
       _assign_target_name:
       extract_module:
       iter_source_files:
+      extract_modules:
       walk_source:
     instruction_files.py:
       MARKER_START:
@@ -111,6 +112,7 @@ src/:
       _render_assignment:
       render_stub:
       _generate_stubs:
+      _write_stubs:
       build_stubs:
     sync.py:
       sync_file:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -123,6 +123,7 @@ tests/:
       test_dedupes_when_claude_md_is_symlink_to_agents_md:
       test_error_when_no_pyproject_toml:
       test_error_when_source_root_missing:
+      test_skip_warning_emitted_once_per_broken_file:
     TestSyncCheckMode:
       test_returns_one_and_does_not_write_on_empty_repo:
       test_returns_zero_when_index_is_up_to_date:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -126,6 +126,7 @@ tests/:
       test_error_when_no_pyproject_toml:
       test_error_when_source_root_missing:
       test_skip_warning_emitted_once_per_broken_file:
+      test_root_param_anchors_reads_at_project_root_when_cwd_is_subdir:
     TestSyncCheckMode:
       test_returns_one_and_does_not_write_on_empty_repo:
       test_returns_zero_when_index_is_up_to_date:
@@ -182,6 +183,10 @@ tests/:
       test_includes_init_with_symbols:
       test_skips_empty_init:
       test_skips_syntax_errors:
+    TestExtractModules:
+      test_returns_module_info_per_parseable_file:
+      test_preserves_source_order:
+      test_skips_files_with_no_symbols:
   test_instruction_files.py:
     TestGenerateSection:
       test_contains_markers:
@@ -267,6 +272,7 @@ tests/:
       test_docstring_starting_with_ie_not_truncated:
       test_docstring_starting_with_us_initialism_not_truncated:
       test_no_docstring:
+      test_whitespace_only_docstring_yields_none:
       test_module_docstring_extracted:
       test_module_no_docstring:
       test_kwargs_and_varargs:
@@ -321,6 +327,10 @@ tests/:
       test_zero_changes_when_clean:
       test_detects_stale_stub_content:
       test_detects_orphan_stub_without_removing_it:
+    TestWriteStubs:
+      test_writes_stubs:
+      test_check_mode_does_not_write:
+      test_prunes_orphan_stubs:
   test_sync.py:
     TestSyncFile:
       test_creates_missing_file:

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -6,12 +6,12 @@ import argparse
 import sys
 from pathlib import Path
 from uncoded.config import find_pyproject_toml, read_instruction_files, read_source_roots
-from uncoded.extract import iter_source_files, walk_source
+from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
-from uncoded.stubs import build_stubs
+from uncoded.stubs import DEFAULT_STUBS_OUTPUT, _generate_stubs, _write_stubs
 from uncoded.sync import sync_file
 
 DEFAULT_MAP_OUTPUT = Path('.uncoded/namespace.yaml')

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -5,7 +5,7 @@
 import argparse
 import sys
 from pathlib import Path
-from uncoded.config import read_instruction_files, read_source_roots
+from uncoded.config import find_pyproject_toml, read_instruction_files, read_source_roots
 from uncoded.extract import walk_source
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
@@ -16,7 +16,7 @@ from uncoded.sync import sync_file
 
 DEFAULT_MAP_OUTPUT = Path('.uncoded/namespace.yaml')
 
-def _sync(*, check: bool) -> int:
+def _sync(*, root: Path | None, check: bool) -> int:
     """Sync (or verify) the namespace map, stub files, and instruction-file sections."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -6,7 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 from uncoded.config import find_pyproject_toml, read_instruction_files, read_source_roots
-from uncoded.extract import walk_source
+from uncoded.extract import iter_source_files, walk_source
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.serena_setup import setup

--- a/.uncoded/stubs/src/uncoded/extract.pyi
+++ b/.uncoded/stubs/src/uncoded/extract.pyi
@@ -4,7 +4,7 @@
 
 import ast
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -24,7 +24,7 @@ def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[st
     """Yield (source_text, rel_path) for every parseable Python file in *source_root*."""
     ...
 
-def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:
+def walk_source(source_root: Path, base: Path | None, *, files: Iterable[tuple[str, str]] | None) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/extract.pyi
+++ b/.uncoded/stubs/src/uncoded/extract.pyi
@@ -24,7 +24,11 @@ def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[st
     """Yield (source_text, rel_path) for every parseable Python file in *source_root*."""
     ...
 
-def walk_source(source_root: Path, base: Path | None, *, files: Iterable[tuple[str, str]] | None) -> list[ModuleInfo]:
+def extract_modules(files: Iterable[tuple[str, str]]) -> list[ModuleInfo]:
+    """Extract a :class:`ModuleInfo` for each file in *files*."""
+    ...
+
+def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -4,6 +4,7 @@
 
 import ast
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from uncoded.extract import _property_kind, iter_source_files
@@ -64,11 +65,11 @@ def render_stub(module: StubModule) -> str:
     """Render a StubModule as a .pyi file string."""
     ...
 
-def _generate_stubs(source_root: Path, base: Path | None) -> dict[Path, str]:
+def _generate_stubs(source_root: Path, base: Path | None, files: Iterable[tuple[str, str]] | None) -> dict[Path, str]:
     """Return a mapping from stub relative paths to rendered stub content."""
     ...
 
-def build_stubs(source_root: Path, output_dir: Path, base: Path | None, *, check: bool) -> int:
+def build_stubs(source_root: Path, output_dir: Path, base: Path | None, *, files: Iterable[tuple[str, str]] | None, check: bool) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -65,11 +65,15 @@ def render_stub(module: StubModule) -> str:
     """Render a StubModule as a .pyi file string."""
     ...
 
-def _generate_stubs(source_root: Path, base: Path | None, files: Iterable[tuple[str, str]] | None) -> dict[Path, str]:
+def _generate_stubs(files: Iterable[tuple[str, str]]) -> dict[Path, str]:
     """Return a mapping from stub relative paths to rendered stub content."""
     ...
 
-def build_stubs(source_root: Path, output_dir: Path, base: Path | None, *, files: Iterable[tuple[str, str]] | None, check: bool) -> int:
+def _write_stubs(stubs: dict[Path, str], source_root: Path, output_dir: Path, base: Path, *, check: bool) -> int:
+    """Write *stubs* under *output_dir* and prune orphans under *source_root*."""
+    ...
+
+def build_stubs(source_root: Path, output_dir: Path, base: Path | None, *, check: bool) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -64,11 +64,11 @@ def render_stub(module: StubModule) -> str:
     """Render a StubModule as a .pyi file string."""
     ...
 
-def _generate_stubs(source_root: Path) -> dict[Path, str]:
+def _generate_stubs(source_root: Path, base: Path | None) -> dict[Path, str]:
     """Return a mapping from stub relative paths to rendered stub content."""
     ...
 
-def build_stubs(source_root: Path, output_dir: Path, *, check: bool) -> int:
+def build_stubs(source_root: Path, output_dir: Path, base: Path | None, *, check: bool) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans."""
     ...
 

--- a/.uncoded/stubs/tests/test_cli.pyi
+++ b/.uncoded/stubs/tests/test_cli.pyi
@@ -29,6 +29,9 @@ class TestSyncApplyMode:
     def test_error_when_source_root_missing(self, tmp_path, monkeypatch, capsys):
         ...
 
+    def test_skip_warning_emitted_once_per_broken_file(self, tmp_path, monkeypatch, capsys):
+        ...
+
 class TestSyncCheckMode:
 
     def test_returns_one_and_does_not_write_on_empty_repo(self, tmp_path, monkeypatch):

--- a/.uncoded/stubs/tests/test_cli.pyi
+++ b/.uncoded/stubs/tests/test_cli.pyi
@@ -32,6 +32,9 @@ class TestSyncApplyMode:
     def test_skip_warning_emitted_once_per_broken_file(self, tmp_path, monkeypatch, capsys):
         ...
 
+    def test_root_param_anchors_reads_at_project_root_when_cwd_is_subdir(self, tmp_path, monkeypatch):
+        ...
+
 class TestSyncCheckMode:
 
     def test_returns_one_and_does_not_write_on_empty_repo(self, tmp_path, monkeypatch):

--- a/.uncoded/stubs/tests/test_extract.pyi
+++ b/.uncoded/stubs/tests/test_extract.pyi
@@ -62,7 +62,6 @@ class TestWalkSource:
         ...
 
 class TestExtractModules:
-    """Pure transformation: ``(source, rel_path)`` pairs to ``ModuleInfo``."""
 
     def test_returns_module_info_per_parseable_file(self):
         ...

--- a/.uncoded/stubs/tests/test_extract.pyi
+++ b/.uncoded/stubs/tests/test_extract.pyi
@@ -1,7 +1,7 @@
 # tests/test_extract.py
 
 import textwrap
-from uncoded.extract import extract_module, walk_source
+from uncoded.extract import extract_module, extract_modules, walk_source
 
 class TestExtractModule:
 
@@ -59,4 +59,16 @@ class TestWalkSource:
         ...
 
     def test_skips_syntax_errors(self, tmp_path, capsys):
+        ...
+
+class TestExtractModules:
+    """Pure transformation: ``(source, rel_path)`` pairs to ``ModuleInfo``."""
+
+    def test_returns_module_info_per_parseable_file(self):
+        ...
+
+    def test_preserves_source_order(self):
+        ...
+
+    def test_skips_files_with_no_symbols(self):
         ...

--- a/.uncoded/stubs/tests/test_skill.pyi
+++ b/.uncoded/stubs/tests/test_skill.pyi
@@ -1,6 +1,5 @@
 # tests/test_skill.py
 
-import os
 from pathlib import Path
 from uncoded.skill import _SKILL_CONTENT, LEGACY_SKILL_OUTPUTS, SKILL_OUTPUTS, sync_skill
 
@@ -9,32 +8,32 @@ class TestSyncSkill:
     def test_skill_name_and_output_paths(self):
         ...
 
-    def test_writes_skill_files(self, tmp_path):
+    def test_writes_skill_files(self, tmp_path, monkeypatch):
         ...
 
-    def test_creates_parent_directories(self, tmp_path):
+    def test_creates_parent_directories(self, tmp_path, monkeypatch):
         ...
 
-    def test_returns_true_on_first_write(self, tmp_path):
+    def test_returns_true_on_first_write(self, tmp_path, monkeypatch):
         ...
 
-    def test_returns_false_when_already_in_sync(self, tmp_path):
+    def test_returns_false_when_already_in_sync(self, tmp_path, monkeypatch):
         ...
 
-    def test_idempotent(self, tmp_path):
+    def test_idempotent(self, tmp_path, monkeypatch):
         ...
 
-    def test_check_mode_does_not_write(self, tmp_path):
+    def test_check_mode_does_not_write(self, tmp_path, monkeypatch):
         ...
 
-    def test_check_mode_reports_change_when_missing(self, tmp_path):
+    def test_check_mode_reports_change_when_missing(self, tmp_path, monkeypatch):
         ...
 
-    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):
+    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path, monkeypatch):
         ...
 
-    def test_removes_legacy_skill_files(self, tmp_path):
+    def test_removes_legacy_skill_files(self, tmp_path, monkeypatch):
         ...
 
-    def test_check_mode_reports_legacy_skill_files_without_removing(self, tmp_path):
+    def test_check_mode_reports_legacy_skill_files_without_removing(self, tmp_path, monkeypatch):
         ...

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -1,6 +1,5 @@
 # tests/test_stubs.py
 
-import os
 import textwrap
 import pytest
 from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, build_stubs, extract_stub, render_stub

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -1,8 +1,9 @@
 # tests/test_stubs.py
 
 import textwrap
+from pathlib import Path
 import pytest
-from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, build_stubs, extract_stub, render_stub
+from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, _write_stubs, build_stubs, extract_stub, render_stub
 
 class TestExtractStub:
 
@@ -40,6 +41,9 @@ class TestExtractStub:
         ...
 
     def test_no_docstring(self):
+        ...
+
+    def test_whitespace_only_docstring_yields_none(self):
         ...
 
     def test_module_docstring_extracted(self):
@@ -201,4 +205,16 @@ class TestBuildStubsCheckMode:
         ...
 
     def test_detects_orphan_stub_without_removing_it(self, tmp_path):
+        ...
+
+class TestWriteStubs:
+    """The IO half: writes stubs from a generated dict, prunes orphans."""
+
+    def test_writes_stubs(self, tmp_path):
+        ...
+
+    def test_check_mode_does_not_write(self, tmp_path):
+        ...
+
+    def test_prunes_orphan_stubs(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -208,7 +208,6 @@ class TestBuildStubsCheckMode:
         ...
 
 class TestWriteStubs:
-    """The IO half: writes stubs from a generated dict, prunes orphans."""
 
     def test_writes_stubs(self, tmp_path):
         ...

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -4,7 +4,11 @@ import argparse
 import sys
 from pathlib import Path
 
-from uncoded.config import read_instruction_files, read_source_roots
+from uncoded.config import (
+    find_pyproject_toml,
+    read_instruction_files,
+    read_source_roots,
+)
 from uncoded.extract import walk_source
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
@@ -16,52 +20,78 @@ from uncoded.sync import sync_file
 DEFAULT_MAP_OUTPUT = Path(".uncoded/namespace.yaml")
 
 
-def _sync(*, check: bool = False) -> int:
+def _sync(*, root: Path | None = None, check: bool = False) -> int:
     """Sync (or verify) the namespace map, stub files, and instruction-file sections.
+
+    ``root`` is the directory the upward walk for ``pyproject.toml``
+    begins from; the parent of the located ``pyproject.toml`` becomes
+    the project anchor used to resolve source-root paths and to render
+    project-relative rel-paths in the namespace map and stubs.
+    Defaults to the current working directory at the CLI boundary.
+    Threading ``root`` through (rather than implicitly fetching cwd at
+    each downstream call site) keeps every working-directory dependency
+    visible in the signature and makes ``_sync`` testable against
+    arbitrary trees.
 
     When ``check=True``, the on-disk tree is not mutated: each step reports
     whether it would write. Returns 1 if any step reports a prospective
     change (so CI can gate on a stale index), 0 if the tree is already in
     sync. In apply mode, returns 0 on success or 1 on configuration error.
     """
-    cwd = Path.cwd()
+    if root is None:
+        root = Path.cwd()
+
+    pyproject_path = find_pyproject_toml(root)
+    if pyproject_path is None:
+        print(
+            "Error: No pyproject.toml found. "
+            "Add [tool.uncoded] source-roots to configure.",
+            file=sys.stderr,
+        )
+        return 1
+    project_root = pyproject_path.parent
+
     try:
-        source_roots = [r.resolve() for r in read_source_roots(cwd)]
-    except (FileNotFoundError, KeyError) as e:
+        source_roots = [
+            (project_root / r).resolve() for r in read_source_roots(project_root)
+        ]
+    except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    for root in source_roots:
-        if not root.is_dir():
-            print(f"Error: {root} is not a directory", file=sys.stderr)
+    for src_root in source_roots:
+        if not src_root.is_dir():
+            print(f"Error: {src_root} is not a directory", file=sys.stderr)
             return 1
 
     changes = 0
 
-    modules = [m for root in source_roots for m in walk_source(root)]
+    modules = [
+        m for src_root in source_roots for m in walk_source(src_root, base=project_root)
+    ]
     map_content = render_map(build_map(modules))
     if sync_file(DEFAULT_MAP_OUTPUT, map_content, check=check):
         changes += 1
 
-    for root in source_roots:
-        changes += build_stubs(root, check=check)
+    for src_root in source_roots:
+        changes += build_stubs(src_root, base=project_root, check=check)
 
     # Dedupe configured instruction paths by resolved (canonical) path.
     # Without this, if CLAUDE.md is a symlink to AGENTS.md, pass 1 writes
     # through the symlink and reports the alias name while pass 2 finds
     # the file already in sync and reports nothing — asymmetric output
     # that hides the actual write target. Resolving collapses both aliases
-    # to the same canonical path, which we render relative to cwd for the
-    # user-facing line, falling back to the absolute resolved path when
-    # the file lives outside cwd.
+    # to the same canonical path, which we render relative to ``root`` for
+    # the user-facing line, falling back to the absolute resolved path when
+    # the file lives outside ``root``.
     seen_resolved: set[Path] = set()
-    for path in read_instruction_files(cwd):
+    for path in read_instruction_files(root):
         resolved = path.resolve()
         if resolved in seen_resolved:
             continue
         seen_resolved.add(resolved)
         try:
-            canonical = resolved.relative_to(cwd)
+            canonical = resolved.relative_to(root)
         except ValueError:
             canonical = resolved
         if sync_instruction_file(canonical, check=check):

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -9,12 +9,12 @@ from uncoded.config import (
     read_instruction_files,
     read_source_roots,
 )
-from uncoded.extract import iter_source_files, walk_source
+from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
-from uncoded.stubs import build_stubs
+from uncoded.stubs import DEFAULT_STUBS_OUTPUT, _generate_stubs, _write_stubs
 from uncoded.sync import sync_file
 
 DEFAULT_MAP_OUTPUT = Path(".uncoded/namespace.yaml")
@@ -67,27 +67,28 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     changes = 0
 
     # Drive a single ``iter_source_files`` pass per source root and feed
-    # both the namespace map and the stubs pipeline from one read. Without
-    # this, each pipeline calls ``iter_source_files`` separately and a
-    # syntax-erroring file produces two identical ``warning: skipping``
-    # lines per ``uncoded sync`` invocation — the contract is one warning
-    # per broken file per sync.
+    # both the namespace map and the stubs pipeline from that one read.
+    # Without this, each pipeline runs ``iter_source_files`` separately
+    # and a syntax-erroring file produces two identical ``warning:
+    # skipping`` lines per ``uncoded sync`` invocation — the contract
+    # is one warning per broken file per sync.
     roots_with_files = [
         (src_root, list(iter_source_files(src_root, base=project_root)))
         for src_root in source_roots
     ]
 
     modules = [
-        m
-        for src_root, files in roots_with_files
-        for m in walk_source(src_root, base=project_root, files=files)
+        m for _src_root, files in roots_with_files for m in extract_modules(files)
     ]
     map_content = render_map(build_map(modules))
     if sync_file(DEFAULT_MAP_OUTPUT, map_content, check=check):
         changes += 1
 
     for src_root, files in roots_with_files:
-        changes += build_stubs(src_root, base=project_root, files=files, check=check)
+        stubs = _generate_stubs(files)
+        changes += _write_stubs(
+            stubs, src_root, DEFAULT_STUBS_OUTPUT, project_root, check=check
+        )
 
     # Dedupe configured instruction paths by resolved (canonical) path.
     # Without this, if CLAUDE.md is a symlink to AGENTS.md, pass 1 writes

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -25,13 +25,13 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
 
     ``root`` is the directory the upward walk for ``pyproject.toml``
     begins from; the parent of the located ``pyproject.toml`` becomes
-    the project anchor used to resolve source-root paths and to render
-    project-relative rel-paths in the namespace map and stubs.
-    Defaults to the current working directory at the CLI boundary.
-    Threading ``root`` through (rather than implicitly fetching cwd at
-    each downstream call site) keeps every working-directory dependency
-    visible in the signature and makes ``_sync`` testable against
-    arbitrary trees.
+    the project anchor used to resolve every project-relative input —
+    source-root paths, instruction-file paths, and the rel-paths
+    rendered into the namespace map and stubs. Defaults to the current
+    working directory at the CLI boundary. Threading ``root`` through
+    (rather than implicitly fetching cwd at each downstream call site)
+    keeps every working-directory dependency visible in the signature
+    and makes ``_sync`` testable against arbitrary trees.
 
     When ``check=True``, the on-disk tree is not mutated: each step reports
     whether it would write. Returns 1 if any step reports a prospective
@@ -81,17 +81,18 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     # through the symlink and reports the alias name while pass 2 finds
     # the file already in sync and reports nothing — asymmetric output
     # that hides the actual write target. Resolving collapses both aliases
-    # to the same canonical path, which we render relative to ``root`` for
-    # the user-facing line, falling back to the absolute resolved path when
-    # the file lives outside ``root``.
+    # to the same canonical path, which we render relative to
+    # ``project_root`` for the user-facing line (matching how source-root
+    # paths resolve), falling back to the absolute resolved path when
+    # the file lives outside ``project_root``.
     seen_resolved: set[Path] = set()
-    for path in read_instruction_files(root):
-        resolved = path.resolve()
+    for path in read_instruction_files(project_root):
+        resolved = (project_root / path).resolve()
         if resolved in seen_resolved:
             continue
         seen_resolved.add(resolved)
         try:
-            canonical = resolved.relative_to(root)
+            canonical = resolved.relative_to(project_root)
         except ValueError:
             canonical = resolved
         if sync_instruction_file(canonical, check=check):

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -25,13 +25,15 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
 
     ``root`` is the directory the upward walk for ``pyproject.toml``
     begins from; the parent of the located ``pyproject.toml`` becomes
-    the project anchor used to resolve every project-relative input —
+    the project anchor used to resolve every project-relative *input* —
     source-root paths, instruction-file paths, and the rel-paths
     rendered into the namespace map and stubs. Defaults to the current
-    working directory at the CLI boundary. Threading ``root`` through
-    (rather than implicitly fetching cwd at each downstream call site)
-    keeps every working-directory dependency visible in the signature
-    and makes ``_sync`` testable against arbitrary trees.
+    working directory at the CLI boundary. Output paths still resolve
+    relative to cwd: ``DEFAULT_MAP_OUTPUT``, ``DEFAULT_STUBS_OUTPUT``,
+    the skill output paths, and the instruction-file write target are
+    all cwd-relative, so running from a subdirectory of the project
+    will land artefacts under that subdirectory rather than the
+    project root. Aligning writes with reads is a separate concern.
 
     When ``check=True``, the on-disk tree is not mutated: each step reports
     whether it would write. Returns 1 if any step reports a prospective

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -9,7 +9,7 @@ from uncoded.config import (
     read_instruction_files,
     read_source_roots,
 )
-from uncoded.extract import walk_source
+from uncoded.extract import iter_source_files, walk_source
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.serena_setup import setup
@@ -66,15 +66,28 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
 
     changes = 0
 
+    # Drive a single ``iter_source_files`` pass per source root and feed
+    # both the namespace map and the stubs pipeline from one read. Without
+    # this, each pipeline calls ``iter_source_files`` separately and a
+    # syntax-erroring file produces two identical ``warning: skipping``
+    # lines per ``uncoded sync`` invocation — the contract is one warning
+    # per broken file per sync.
+    roots_with_files = [
+        (src_root, list(iter_source_files(src_root, base=project_root)))
+        for src_root in source_roots
+    ]
+
     modules = [
-        m for src_root in source_roots for m in walk_source(src_root, base=project_root)
+        m
+        for src_root, files in roots_with_files
+        for m in walk_source(src_root, base=project_root, files=files)
     ]
     map_content = render_map(build_map(modules))
     if sync_file(DEFAULT_MAP_OUTPUT, map_content, check=check):
         changes += 1
 
-    for src_root in source_roots:
-        changes += build_stubs(src_root, base=project_root, check=check)
+    for src_root, files in roots_with_files:
+        changes += build_stubs(src_root, base=project_root, files=files, check=check)
 
     # Dedupe configured instruction paths by resolved (canonical) path.
     # Without this, if CLAUDE.md is a symlink to AGENTS.md, pass 1 writes

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -33,7 +33,7 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     the skill output paths, and the instruction-file write target are
     all cwd-relative, so running from a subdirectory of the project
     will land artefacts under that subdirectory rather than the
-    project root. Aligning writes with reads is a separate concern.
+    project root.
 
     When ``check=True``, the on-disk tree is not mutated: each step reports
     whether it would write. Returns 1 if any step reports a prospective
@@ -68,12 +68,6 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
 
     changes = 0
 
-    # Drive a single ``iter_source_files`` pass per source root and feed
-    # both the namespace map and the stubs pipeline from that one read.
-    # Without this, each pipeline runs ``iter_source_files`` separately
-    # and a syntax-erroring file produces two identical ``warning:
-    # skipping`` lines per ``uncoded sync`` invocation — the contract
-    # is one warning per broken file per sync.
     roots_with_files = [
         (src_root, list(iter_source_files(src_root, base=project_root)))
         for src_root in source_roots
@@ -98,9 +92,8 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     # the file already in sync and reports nothing — asymmetric output
     # that hides the actual write target. Resolving collapses both aliases
     # to the same canonical path, which we render relative to
-    # ``project_root`` for the user-facing line (matching how source-root
-    # paths resolve), falling back to the absolute resolved path when
-    # the file lives outside ``project_root``.
+    # ``project_root`` for the user-facing line, falling back to the
+    # absolute resolved path when the file lives outside ``project_root``.
     seen_resolved: set[Path] = set()
     for path in read_instruction_files(project_root):
         resolved = (project_root / path).resolve()

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -130,38 +130,37 @@ def iter_source_files(
         yield source, rel_path
 
 
-def walk_source(
-    source_root: Path,
-    base: Path | None = None,
-    *,
-    files: Iterable[tuple[str, str]] | None = None,
-) -> list[ModuleInfo]:
+def extract_modules(files: Iterable[tuple[str, str]]) -> list[ModuleInfo]:
+    """Extract a :class:`ModuleInfo` for each file in *files*.
+
+    *files* is the output of :func:`iter_source_files` — an iterable of
+    ``(source, rel_path)`` pairs where the source has already been
+    confirmed parseable. Pure transformation: no IO, no warnings, no
+    parsing decisions. Skips files with no symbols.
+
+    This is the layer ``cli._sync`` calls directly when it has driven a
+    single ``iter_source_files`` pass per source root and wants to feed
+    both the namespace map and the stubs pipeline from that pass without
+    a second walk. The :func:`walk_source` wrapper combines the two
+    steps for callers that want the one-shot convenience.
+    """
+    modules: list[ModuleInfo] = []
+    for source, rel_path in files:
+        module = extract_module(source, rel_path)
+        if module.classes or module.functions or module.constants:
+            modules.append(module)
+    return modules
+
+
+def walk_source(source_root: Path, base: Path | None = None) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files.
 
     Paths in the returned ModuleInfo are relative to *base* (defaults to
     cwd), so they can be used directly to open files from the repo root.
 
-    When *files* is provided, the file scan is skipped and the iterable
-    is consumed directly — the iterable is expected to be the output of
-    :func:`iter_source_files`. This lets a caller drive a single
-    ``iter_source_files`` pass and feed multiple consumers (e.g.
-    namespace map and stubs) from one read, so a syntax-erroring file
-    is read, parsed, and warned about exactly once per pass instead of
-    once per consumer. When *files* is provided, *source_root* and
-    *base* are unused.
-
-    Skips files with no symbols. Files with syntax errors are filtered
-    out upstream by ``iter_source_files`` (which emits a stderr warning
-    naming the offending file).
+    Convenience wrapper around :func:`iter_source_files` and
+    :func:`extract_modules`. Files with syntax errors are filtered out
+    by ``iter_source_files`` (which emits a stderr warning naming the
+    offending file).
     """
-    if files is None:
-        files = iter_source_files(source_root, base)
-
-    modules: list[ModuleInfo] = []
-
-    for source, rel_path in files:
-        module = extract_module(source, rel_path)
-        if module.classes or module.functions or module.constants:
-            modules.append(module)
-
-    return modules
+    return extract_modules(iter_source_files(source_root, base))

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -2,7 +2,7 @@
 
 import ast
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -130,19 +130,36 @@ def iter_source_files(
         yield source, rel_path
 
 
-def walk_source(source_root: Path, base: Path | None = None) -> list[ModuleInfo]:
+def walk_source(
+    source_root: Path,
+    base: Path | None = None,
+    *,
+    files: Iterable[tuple[str, str]] | None = None,
+) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files.
 
     Paths in the returned ModuleInfo are relative to *base* (defaults to
     cwd), so they can be used directly to open files from the repo root.
 
+    When *files* is provided, the file scan is skipped and the iterable
+    is consumed directly — the iterable is expected to be the output of
+    :func:`iter_source_files`. This lets a caller drive a single
+    ``iter_source_files`` pass and feed multiple consumers (e.g.
+    namespace map and stubs) from one read, so a syntax-erroring file
+    is read, parsed, and warned about exactly once per pass instead of
+    once per consumer. When *files* is provided, *source_root* and
+    *base* are unused.
+
     Skips files with no symbols. Files with syntax errors are filtered
     out upstream by ``iter_source_files`` (which emits a stderr warning
     naming the offending file).
     """
+    if files is None:
+        files = iter_source_files(source_root, base)
+
     modules: list[ModuleInfo] = []
 
-    for source, rel_path in iter_source_files(source_root, base):
+    for source, rel_path in files:
         module = extract_module(source, rel_path)
         if module.classes or module.functions or module.constants:
             modules.append(module)

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -137,12 +137,6 @@ def extract_modules(files: Iterable[tuple[str, str]]) -> list[ModuleInfo]:
     ``(source, rel_path)`` pairs where the source has already been
     confirmed parseable. Pure transformation: no IO, no warnings, no
     parsing decisions. Skips files with no symbols.
-
-    This is the layer ``cli._sync`` calls directly when it has driven a
-    single ``iter_source_files`` pass per source root and wants to feed
-    both the namespace map and the stubs pipeline from that pass without
-    a second walk. The :func:`walk_source` wrapper combines the two
-    steps for callers that want the one-shot convenience.
     """
     modules: list[ModuleInfo] = []
     for source, rel_path in files:

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -2,6 +2,7 @@
 
 import ast
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -337,10 +338,16 @@ def render_stub(module: StubModule) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _generate_stubs(source_root: Path, base: Path | None = None) -> dict[Path, str]:
+def _generate_stubs(
+    source_root: Path,
+    base: Path | None = None,
+    files: Iterable[tuple[str, str]] | None = None,
+) -> dict[Path, str]:
     """Return a mapping from stub relative paths to rendered stub content."""
+    if files is None:
+        files = iter_source_files(source_root, base)
     result: dict[Path, str] = {}
-    for source, rel_path in iter_source_files(source_root, base):
+    for source, rel_path in files:
         module = extract_stub(source, rel_path)
         if not module.classes and not module.functions and not module.constants:
             continue
@@ -356,6 +363,7 @@ def build_stubs(
     output_dir: Path = DEFAULT_STUBS_OUTPUT,
     base: Path | None = None,
     *,
+    files: Iterable[tuple[str, str]] | None = None,
     check: bool = False,
 ) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans.
@@ -374,6 +382,14 @@ def build_stubs(
     ``source_root.relative_to(base)``, so ``base`` must be an ancestor of
     ``source_root`` for cleanup to run; otherwise cleanup is skipped.
 
+    When *files* is provided, stub generation consumes the iterable directly
+    (expected to be the output of :func:`iter_source_files`) instead of
+    re-scanning ``source_root``. This lets a caller drive a single
+    ``iter_source_files`` pass and feed both the namespace-map and the stub
+    pipelines from one read, so a syntax-erroring file is read, parsed, and
+    warned about exactly once per ``uncoded sync`` invocation. The orphan
+    cleanup still runs against ``source_root`` regardless.
+
     When ``check=True``, the on-disk tree is not mutated; instead, prospective
     writes and removals are reported and counted. Returns the number of
     changes (or prospective changes).
@@ -384,7 +400,9 @@ def build_stubs(
 
     changes = 0
     expected: set[Path] = set()
-    for rel_stub_path, content in _generate_stubs(source_root, base).items():
+    for rel_stub_path, content in _generate_stubs(
+        source_root, base, files=files
+    ).items():
         stub_path = output_dir / rel_stub_path
         if sync_file(stub_path, content, check=check):
             changes += 1

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -337,10 +337,10 @@ def render_stub(module: StubModule) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _generate_stubs(source_root: Path) -> dict[Path, str]:
+def _generate_stubs(source_root: Path, base: Path | None = None) -> dict[Path, str]:
     """Return a mapping from stub relative paths to rendered stub content."""
     result: dict[Path, str] = {}
-    for source, rel_path in iter_source_files(source_root):
+    for source, rel_path in iter_source_files(source_root, base):
         module = extract_stub(source, rel_path)
         if not module.classes and not module.functions and not module.constants:
             continue
@@ -354,6 +354,7 @@ DEFAULT_STUBS_OUTPUT = Path(".uncoded/stubs")
 def build_stubs(
     source_root: Path,
     output_dir: Path = DEFAULT_STUBS_OUTPUT,
+    base: Path | None = None,
     *,
     check: bool = False,
 ) -> int:
@@ -366,23 +367,33 @@ def build_stubs(
     subtree corresponding to ``source_root`` is touched, so other source
     roots' stubs are not affected.
 
+    Stub paths are rendered relative to *base* (defaulting to cwd), so the
+    rendered ``rel_path`` headers match the project-relative paths that
+    :func:`walk_source` and the namespace map use. The orphan-cleanup pass
+    walks the subtree of ``output_dir`` corresponding to
+    ``source_root.relative_to(base)``, so ``base`` must be an ancestor of
+    ``source_root`` for cleanup to run; otherwise cleanup is skipped.
+
     When ``check=True``, the on-disk tree is not mutated; instead, prospective
     writes and removals are reported and counted. Returns the number of
     changes (or prospective changes).
     """
+    if base is None:
+        base = Path.cwd()
+    base = base.resolve()
+
     changes = 0
     expected: set[Path] = set()
-    for rel_stub_path, content in _generate_stubs(source_root).items():
+    for rel_stub_path, content in _generate_stubs(source_root, base).items():
         stub_path = output_dir / rel_stub_path
         if sync_file(stub_path, content, check=check):
             changes += 1
         expected.add(stub_path.resolve())
 
-    base = Path.cwd().resolve()
     try:
         source_rel = source_root.resolve().relative_to(base)
     except ValueError:
-        # source_root is outside cwd; we have no safe subtree to clean.
+        # source_root is outside base; we have no safe subtree to clean.
         return changes
     stubs_root = output_dir / source_rel
     if not stubs_root.exists():

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -338,14 +338,14 @@ def render_stub(module: StubModule) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _generate_stubs(
-    source_root: Path,
-    base: Path | None = None,
-    files: Iterable[tuple[str, str]] | None = None,
-) -> dict[Path, str]:
-    """Return a mapping from stub relative paths to rendered stub content."""
-    if files is None:
-        files = iter_source_files(source_root, base)
+def _generate_stubs(files: Iterable[tuple[str, str]]) -> dict[Path, str]:
+    """Return a mapping from stub relative paths to rendered stub content.
+
+    *files* is the output of :func:`iter_source_files` — an iterable of
+    ``(source, rel_path)`` pairs. Pure transformation: no IO, no
+    warnings, no parsing decisions. Modules with no symbols are
+    skipped.
+    """
     result: dict[Path, str] = {}
     for source, rel_path in files:
         module = extract_stub(source, rel_path)
@@ -358,51 +358,38 @@ def _generate_stubs(
 DEFAULT_STUBS_OUTPUT = Path(".uncoded/stubs")
 
 
-def build_stubs(
+def _write_stubs(
+    stubs: dict[Path, str],
     source_root: Path,
-    output_dir: Path = DEFAULT_STUBS_OUTPUT,
-    base: Path | None = None,
+    output_dir: Path,
+    base: Path,
     *,
-    files: Iterable[tuple[str, str]] | None = None,
-    check: bool = False,
+    check: bool,
 ) -> int:
-    """Sync stub files for all symbols under source_root, removing any orphans.
+    """Write *stubs* under *output_dir* and prune orphans under *source_root*.
 
-    Writes only files whose content has changed. After reconciling the current
-    set of stubs, any pre-existing ``.pyi`` files in the corresponding subtree
-    of ``output_dir`` whose source has been removed or renamed are deleted,
-    and any directories left empty by the deletion are pruned. Only the
-    subtree corresponding to ``source_root`` is touched, so other source
-    roots' stubs are not affected.
+    *stubs* maps each stub's relative path (under *output_dir*) to its
+    rendered content; typically the return value of
+    :func:`_generate_stubs`. *base* must already be resolved — it
+    anchors the orphan-cleanup subtree at
+    ``output_dir / source_root.relative_to(base)``, so ``base`` must
+    be an ancestor of ``source_root`` for cleanup to run; otherwise
+    cleanup is skipped.
 
-    Stub paths are rendered relative to *base* (defaulting to cwd), so the
-    rendered ``rel_path`` headers match the project-relative paths that
-    :func:`walk_source` and the namespace map use. The orphan-cleanup pass
-    walks the subtree of ``output_dir`` corresponding to
-    ``source_root.relative_to(base)``, so ``base`` must be an ancestor of
-    ``source_root`` for cleanup to run; otherwise cleanup is skipped.
+    Writes only files whose content has changed. After reconciling the
+    current set of stubs, any pre-existing ``.pyi`` files in the
+    corresponding subtree whose source has been removed or renamed are
+    deleted, and any directories left empty by the deletion are
+    pruned. Only the subtree corresponding to ``source_root`` is
+    touched, so other source roots' stubs are not affected.
 
-    When *files* is provided, stub generation consumes the iterable directly
-    (expected to be the output of :func:`iter_source_files`) instead of
-    re-scanning ``source_root``. This lets a caller drive a single
-    ``iter_source_files`` pass and feed both the namespace-map and the stub
-    pipelines from one read, so a syntax-erroring file is read, parsed, and
-    warned about exactly once per ``uncoded sync`` invocation. The orphan
-    cleanup still runs against ``source_root`` regardless.
-
-    When ``check=True``, the on-disk tree is not mutated; instead, prospective
-    writes and removals are reported and counted. Returns the number of
-    changes (or prospective changes).
+    When ``check=True``, the on-disk tree is not mutated; instead,
+    prospective writes and removals are reported and counted. Returns
+    the number of changes (or prospective changes).
     """
-    if base is None:
-        base = Path.cwd()
-    base = base.resolve()
-
     changes = 0
     expected: set[Path] = set()
-    for rel_stub_path, content in _generate_stubs(
-        source_root, base, files=files
-    ).items():
+    for rel_stub_path, content in stubs.items():
         stub_path = output_dir / rel_stub_path
         if sync_file(stub_path, content, check=check):
             changes += 1
@@ -430,3 +417,29 @@ def build_stubs(
             d.rmdir()
 
     return changes
+
+
+def build_stubs(
+    source_root: Path,
+    output_dir: Path = DEFAULT_STUBS_OUTPUT,
+    base: Path | None = None,
+    *,
+    check: bool = False,
+) -> int:
+    """Sync stub files for all symbols under source_root, removing any orphans.
+
+    Convenience wrapper around :func:`iter_source_files`,
+    :func:`_generate_stubs`, and :func:`_write_stubs`. Stub paths are
+    rendered relative to *base* (defaulting to cwd), so the rendered
+    ``rel_path`` headers match the project-relative paths that
+    :func:`walk_source` and the namespace map use.
+
+    When ``check=True``, the on-disk tree is not mutated; instead,
+    prospective writes and removals are reported and counted. Returns
+    the number of changes (or prospective changes).
+    """
+    if base is None:
+        base = Path.cwd()
+    base = base.resolve()
+    stubs = _generate_stubs(iter_source_files(source_root, base))
+    return _write_stubs(stubs, source_root, output_dir, base, check=check)

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -78,22 +78,22 @@ def _first_sentence(
     docstring = ast.get_docstring(node)
     if not docstring:
         return None
-    text = docstring.strip()
-    # Sentence boundary: ``.`` followed by whitespace and a capital letter.
-    # The capital-letter requirement prevents truncation at common
-    # abbreviations whose period is followed by lowercase continuation
-    # (``e.g. parse...``, ``i.e. ...``, ``U.S. economic policy``). The
-    # appended ``" Z"`` sentinel acts as an end-of-text boundary so a
-    # single-sentence docstring (no follow-on text) is matched in full
-    # rather than falling through to the line-based fallback.
-    # Known limitation, not fixed by this heuristic: title+capital-name
-    # pairs like ``Mr. Smith arrived.`` or ``Dr. Jones examined.`` still
-    # truncate at the abbreviation, because the capital is genuinely
-    # there. Disambiguating those would need a tokeniser or a whitelist.
-    match = re.match(r"(.+?\.)\s+[A-Z]", text + " Z")
-    if match:
-        return match.group(1)
-    return text.split("\n")[0].strip()
+    # Sentence boundary: ``.`` followed by whitespace and a capital
+    # letter. The capital-letter requirement prevents truncation at
+    # common abbreviations whose period is followed by lowercase
+    # continuation (``e.g. parse...``, ``i.e. ...``, ``U.S. economic
+    # policy``). When no period+space+capital boundary exists in the
+    # text — single-sentence, period-less, or multi-line docstrings —
+    # the second alternative returns the text up to the first newline
+    # (we append a trailing ``\n`` to guarantee one). Known limitation:
+    # title plus capital-name pairs like ``Mr. Smith arrived.`` or
+    # ``Dr. Jones examined.`` still truncate at the abbreviation,
+    # because the capital is genuinely there. Disambiguating those
+    # would need a tokeniser or a whitelist.
+    match = re.match(r"(.+?\.(?=\s+[A-Z])|.+?(?=\n))", docstring.strip() + "\n")
+    if match is None:
+        return None
+    return match.group(1)
 
 
 def _extract_params(args: ast.arguments) -> list[StubParam]:

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -78,18 +78,12 @@ def _first_sentence(
     docstring = ast.get_docstring(node)
     if not docstring:
         return None
-    # Sentence boundary: ``.`` followed by whitespace and a capital
-    # letter. The capital-letter requirement prevents truncation at
-    # common abbreviations whose period is followed by lowercase
-    # continuation (``e.g. parse...``, ``i.e. ...``, ``U.S. economic
-    # policy``). When no period+space+capital boundary exists in the
-    # text — single-sentence, period-less, or multi-line docstrings —
-    # the second alternative returns the text up to the first newline
-    # (we append a trailing ``\n`` to guarantee one). Known limitation:
-    # title plus capital-name pairs like ``Mr. Smith arrived.`` or
-    # ``Dr. Jones examined.`` still truncate at the abbreviation,
-    # because the capital is genuinely there. Disambiguating those
-    # would need a tokeniser or a whitelist.
+    # Sentence boundary: ``.`` followed by whitespace and a capital.
+    # The capital-letter requirement avoids truncation at lowercase-
+    # after-period abbreviations like ``e.g.``, ``i.e.``, ``U.S.``.
+    # Known limitation: ``Mr. Smith arrived.`` still truncates at the
+    # abbreviation, because the capital is genuinely there.
+    # Disambiguating those would need a tokeniser or a whitelist.
     match = re.match(r"(.+?\.(?=\s+[A-Z])|.+?(?=\n))", docstring.strip() + "\n")
     if match is None:
         return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,50 @@ class TestSyncApplyMode:
         assert len(skip_warnings) == 1
         assert skip_warnings[0].startswith("warning: skipping src/broken.py")
         assert "SyntaxError" in skip_warnings[0]
+        # Pipeline still completes for the non-broken file: the half of
+        # the contract the warning-count assertion alone doesn't pin.
+        assert (tmp_path / ".uncoded" / "stubs" / "src" / "good.pyi").exists()
+
+    def test_root_param_anchors_reads_at_project_root_when_cwd_is_subdir(
+        self, tmp_path, monkeypatch
+    ):
+        # When ``_sync(root=...)`` is called with cwd inside a project
+        # subdirectory, the *read* anchor (source-root resolution and
+        # rel-path rendering in the namespace map) follows the project
+        # root derived from ``root``, not cwd. Output paths are still
+        # cwd-relative — that's documented as a separate concern, so
+        # this test only pins the read seam.
+        (tmp_path / "pyproject.toml").write_text(
+            textwrap.dedent(
+                """\
+                [project]
+                name = "demo"
+
+                [tool.uncoded]
+                source-roots = ["src"]
+                """
+            )
+        )
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "foo.py").write_text("def hello(): pass\n")
+        # cwd is the source subdirectory; the seam under test is whether
+        # ``root=tmp_path`` re-anchors reads at the project root.
+        monkeypatch.chdir(tmp_path / "src")
+
+        assert cli._sync(root=tmp_path) == 0
+
+        # Output paths are cwd-relative; namespace.yaml landed under the
+        # subdirectory we ran from. That's the documented behaviour.
+        namespace_path = tmp_path / "src" / ".uncoded" / "namespace.yaml"
+        assert namespace_path.exists()
+
+        # The rel-path inside is project-anchored: ``src/foo.py`` (from
+        # tmp_path), not ``foo.py`` (from cwd). If the read anchor had
+        # leaked back to cwd, the file would appear as a top-level
+        # ``foo.py`` key with no ``src/`` directory wrapper.
+        content = namespace_path.read_text()
+        assert "src/:" in content
+        assert "foo.py:" in content
 
 
 class TestSyncCheckMode:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,29 @@ class TestSyncApplyMode:
         assert cli._sync() == 1
         assert "Error" in capsys.readouterr().err
 
+    def test_skip_warning_emitted_once_per_broken_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # A syntax-erroring source file must produce exactly one stderr
+        # warning per ``uncoded sync`` invocation. Before the dedup fix,
+        # ``walk_source`` and ``_generate_stubs`` each ran
+        # ``iter_source_files`` separately and each warned, so a single
+        # broken file produced two identical lines on stderr.
+        _init_repo(tmp_path, monkeypatch)
+        (tmp_path / "src" / "good.py").write_text("def hello(): pass\n")
+        (tmp_path / "src" / "broken.py").write_text("def bad(:\n")
+
+        assert cli._sync() == 0
+
+        skip_warnings = [
+            line
+            for line in capsys.readouterr().err.splitlines()
+            if "skipping" in line and "broken.py" in line
+        ]
+        assert len(skip_warnings) == 1
+        assert skip_warnings[0].startswith("warning: skipping src/broken.py")
+        assert "SyntaxError" in skip_warnings[0]
+
 
 class TestSyncCheckMode:
     def test_returns_one_and_does_not_write_on_empty_repo(self, tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,11 +126,6 @@ class TestSyncApplyMode:
     def test_skip_warning_emitted_once_per_broken_file(
         self, tmp_path, monkeypatch, capsys
     ):
-        # A syntax-erroring source file must produce exactly one stderr
-        # warning per ``uncoded sync`` invocation. Before the dedup fix,
-        # ``walk_source`` and ``_generate_stubs`` each ran
-        # ``iter_source_files`` separately and each warned, so a single
-        # broken file produced two identical lines on stderr.
         _init_repo(tmp_path, monkeypatch)
         (tmp_path / "src" / "good.py").write_text("def hello(): pass\n")
         (tmp_path / "src" / "broken.py").write_text("def bad(:\n")
@@ -145,19 +140,11 @@ class TestSyncApplyMode:
         assert len(skip_warnings) == 1
         assert skip_warnings[0].startswith("warning: skipping src/broken.py")
         assert "SyntaxError" in skip_warnings[0]
-        # Pipeline still completes for the non-broken file: the half of
-        # the contract the warning-count assertion alone doesn't pin.
         assert (tmp_path / ".uncoded" / "stubs" / "src" / "good.pyi").exists()
 
     def test_root_param_anchors_reads_at_project_root_when_cwd_is_subdir(
         self, tmp_path, monkeypatch
     ):
-        # When ``_sync(root=...)`` is called with cwd inside a project
-        # subdirectory, the *read* anchor (source-root resolution and
-        # rel-path rendering in the namespace map) follows the project
-        # root derived from ``root``, not cwd. Output paths are still
-        # cwd-relative — that's documented as a separate concern, so
-        # this test only pins the read seam.
         (tmp_path / "pyproject.toml").write_text(
             textwrap.dedent(
                 """\
@@ -171,21 +158,12 @@ class TestSyncApplyMode:
         )
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "foo.py").write_text("def hello(): pass\n")
-        # cwd is the source subdirectory; the seam under test is whether
-        # ``root=tmp_path`` re-anchors reads at the project root.
         monkeypatch.chdir(tmp_path / "src")
 
         assert cli._sync(root=tmp_path) == 0
 
-        # Output paths are cwd-relative; namespace.yaml landed under the
-        # subdirectory we ran from. That's the documented behaviour.
         namespace_path = tmp_path / "src" / ".uncoded" / "namespace.yaml"
         assert namespace_path.exists()
-
-        # The rel-path inside is project-anchored: ``src/foo.py`` (from
-        # tmp_path), not ``foo.py`` (from cwd). If the read anchor had
-        # leaked back to cwd, the file would appear as a top-level
-        # ``foo.py`` key with no ``src/`` directory wrapper.
         content = namespace_path.read_text()
         assert "src/:" in content
         assert "foo.py:" in content

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from uncoded.extract import extract_module, walk_source
+from uncoded.extract import extract_module, extract_modules, walk_source
 
 
 class TestExtractModule:
@@ -293,3 +293,47 @@ class TestWalkSource:
         err = capsys.readouterr().err
         assert "warning: skipping src/mypackage/bad.py" in err
         assert "SyntaxError" in err
+
+
+class TestExtractModules:
+    """Pure transformation: ``(source, rel_path)`` pairs to ``ModuleInfo``."""
+
+    def test_returns_module_info_per_parseable_file(self):
+        files = [
+            ("def foo(): pass\n", "src/a.py"),
+            ("class Bar: pass\n", "src/b.py"),
+        ]
+
+        modules = extract_modules(files)
+
+        assert [m.rel_path for m in modules] == ["src/a.py", "src/b.py"]
+        assert modules[0].functions == ["foo"]
+        assert modules[1].classes[0].name == "Bar"
+
+    def test_preserves_source_order(self):
+        # Order is the caller's contract — ``iter_source_files`` produces
+        # sorted output, and ``extract_modules`` must preserve it so the
+        # rendered namespace map is reproducible.
+        files = [
+            ("def a(): pass\n", "src/a.py"),
+            ("def b(): pass\n", "src/b.py"),
+            ("def c(): pass\n", "src/c.py"),
+        ]
+
+        modules = extract_modules(files)
+
+        assert [m.rel_path for m in modules] == ["src/a.py", "src/b.py", "src/c.py"]
+
+    def test_skips_files_with_no_symbols(self):
+        # A comment-only file produces a ``ModuleInfo`` with no classes,
+        # functions, or constants — those are filtered out so the
+        # namespace map doesn't carry empty-leaf entries.
+        files = [
+            ("def foo(): pass\n", "src/a.py"),
+            ("# nothing here\n", "src/empty.py"),
+            ("class Bar: pass\n", "src/b.py"),
+        ]
+
+        modules = extract_modules(files)
+
+        assert [m.rel_path for m in modules] == ["src/a.py", "src/b.py"]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -296,8 +296,6 @@ class TestWalkSource:
 
 
 class TestExtractModules:
-    """Pure transformation: ``(source, rel_path)`` pairs to ``ModuleInfo``."""
-
     def test_returns_module_info_per_parseable_file(self):
         files = [
             ("def foo(): pass\n", "src/a.py"),
@@ -311,9 +309,6 @@ class TestExtractModules:
         assert modules[1].classes[0].name == "Bar"
 
     def test_preserves_source_order(self):
-        # Order is the caller's contract — ``iter_source_files`` produces
-        # sorted output, and ``extract_modules`` must preserve it so the
-        # rendered namespace map is reproducible.
         files = [
             ("def a(): pass\n", "src/a.py"),
             ("def b(): pass\n", "src/b.py"),
@@ -325,9 +320,6 @@ class TestExtractModules:
         assert [m.rel_path for m in modules] == ["src/a.py", "src/b.py", "src/c.py"]
 
     def test_skips_files_with_no_symbols(self):
-        # A comment-only file produces a ``ModuleInfo`` with no classes,
-        # functions, or constants — those are filtered out so the
-        # namespace map doesn't carry empty-leaf entries.
         files = [
             ("def foo(): pass\n", "src/a.py"),
             ("# nothing here\n", "src/empty.py"),

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from uncoded.skill import (
@@ -18,31 +17,31 @@ class TestSyncSkill:
         assert "name: coherence-review\n" in _SKILL_CONTENT
         assert "name: uncoded-review\n" not in _SKILL_CONTENT
 
-    def test_writes_skill_files(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_writes_skill_files(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         sync_skill(check=False)
         for path in SKILL_OUTPUTS:
             skill_path = tmp_path / path
             assert skill_path.exists()
             assert skill_path.read_text() == _SKILL_CONTENT
 
-    def test_creates_parent_directories(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_creates_parent_directories(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         sync_skill(check=False)
         for path in SKILL_OUTPUTS:
             assert (tmp_path / path).parent.is_dir()
 
-    def test_returns_true_on_first_write(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_returns_true_on_first_write(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         assert sync_skill(check=False) is True
 
-    def test_returns_false_when_already_in_sync(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_returns_false_when_already_in_sync(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         sync_skill(check=False)
         assert sync_skill(check=False) is False
 
-    def test_idempotent(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         sync_skill(check=False)
         mtimes = [(tmp_path / path).stat().st_mtime_ns for path in SKILL_OUTPUTS]
         sync_skill(check=False)
@@ -50,23 +49,23 @@ class TestSyncSkill:
             (tmp_path / path).stat().st_mtime_ns for path in SKILL_OUTPUTS
         ] == mtimes
 
-    def test_check_mode_does_not_write(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_check_mode_does_not_write(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         sync_skill(check=True)
         for path in SKILL_OUTPUTS:
             assert not (tmp_path / path).exists()
 
-    def test_check_mode_reports_change_when_missing(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_check_mode_reports_change_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         assert sync_skill(check=True) is True
 
-    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_check_mode_reports_no_change_when_in_sync(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         sync_skill(check=False)
         assert sync_skill(check=True) is False
 
-    def test_removes_legacy_skill_files(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_removes_legacy_skill_files(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
         for path in LEGACY_SKILL_OUTPUTS:
             legacy_path = tmp_path / path
             legacy_path.parent.mkdir(parents=True, exist_ok=True)
@@ -77,8 +76,10 @@ class TestSyncSkill:
         for path in LEGACY_SKILL_OUTPUTS:
             assert not (tmp_path / path).exists()
 
-    def test_check_mode_reports_legacy_skill_files_without_removing(self, tmp_path):
-        os.chdir(tmp_path)
+    def test_check_mode_reports_legacy_skill_files_without_removing(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
         for path in LEGACY_SKILL_OUTPUTS:
             legacy_path = tmp_path / path
             legacy_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -8,6 +9,7 @@ from uncoded.stubs import (
     StubFunction,
     StubModule,
     StubParam,
+    _write_stubs,
     build_stubs,
     extract_stub,
     render_stub,
@@ -152,6 +154,20 @@ class TestExtractStub:
                 pass
         """)
         module = extract_stub(source, "pkg/silent.py")
+        assert module.functions[0].docstring_excerpt is None
+
+    def test_whitespace_only_docstring_yields_none(self):
+        # A whitespace-only docstring is observably a docstring at the
+        # AST level but carries no content. ``ast.get_docstring`` with
+        # the default ``clean=True`` cleans it to an empty string, which
+        # ``_first_sentence`` short-circuits as ``None`` rather than
+        # returning an empty excerpt.
+        source = textwrap.dedent("""\
+            def whitespace_only():
+                '''   '''
+                pass
+        """)
+        module = extract_stub(source, "pkg/whitespace.py")
         assert module.functions[0].docstring_excerpt is None
 
     def test_module_docstring_extracted(self):
@@ -696,3 +712,51 @@ class TestBuildStubsCheckMode:
         assert build_stubs(src, out, base=tmp_path, check=True) == 1
         # Check mode must not mutate the tree — orphan is still there.
         assert (out / "src" / "bar.pyi").exists()
+
+
+class TestWriteStubs:
+    """The IO half: writes stubs from a generated dict, prunes orphans."""
+
+    def test_writes_stubs(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        out = tmp_path / "stubs"
+        stubs = {Path("src/foo.pyi"): "# stub\n"}
+
+        changes = _write_stubs(stubs, src, out, tmp_path, check=False)
+
+        assert changes == 1
+        assert (out / "src" / "foo.pyi").read_text() == "# stub\n"
+
+    def test_check_mode_does_not_write(self, tmp_path):
+        # Symmetric with ``sync_file``'s check-mode contract: report what
+        # would change, mutate nothing.
+        src = tmp_path / "src"
+        src.mkdir()
+        out = tmp_path / "stubs"
+        stubs = {Path("src/foo.pyi"): "# stub\n"}
+
+        changes = _write_stubs(stubs, src, out, tmp_path, check=True)
+
+        assert changes == 1
+        assert not (out / "src" / "foo.pyi").exists()
+
+    def test_prunes_orphan_stubs(self, tmp_path):
+        # Pre-existing stub under a subpackage of the source-root
+        # subtree whose source has been removed (modelled here by an
+        # empty stubs dict) should be deleted, and child directories
+        # left empty by the deletion should be pruned. The
+        # source-root stub directory itself is preserved — that's
+        # ``_write_stubs``'s "keep stubs_root itself" contract.
+        src = tmp_path / "src"
+        src.mkdir()
+        out = tmp_path / "stubs"
+        (out / "src" / "pkg").mkdir(parents=True)
+        (out / "src" / "pkg" / "orphan.pyi").write_text("# stale\n")
+
+        changes = _write_stubs({}, src, out, tmp_path, check=False)
+
+        assert changes == 1
+        assert not (out / "src" / "pkg" / "orphan.pyi").exists()
+        assert not (out / "src" / "pkg").exists()  # empty subpackage pruned
+        assert (out / "src").exists()  # source-root stub dir preserved

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,4 +1,3 @@
-import os
 import textwrap
 
 import pytest
@@ -572,7 +571,6 @@ class TestBuildStubs:
     """build_stubs writes expected stubs and removes orphans for its source root."""
 
     def _setup(self, tmp_path):
-        os.chdir(tmp_path)
         src = tmp_path / "src"
         src.mkdir()
         out = tmp_path / "stubs"
@@ -581,29 +579,29 @@ class TestBuildStubs:
     def test_writes_expected_stubs(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "src" / "foo.pyi").exists()
 
     def test_removes_orphan_stub_when_source_deleted(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "src" / "bar.pyi").exists()
 
         (src / "bar.py").unlink()
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "src" / "foo.pyi").exists()
         assert not (out / "src" / "bar.pyi").exists()
 
     def test_removes_orphan_stub_when_source_renamed(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "old_name.py").write_text("def hello(): pass\n")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "src" / "old_name.pyi").exists()
 
         (src / "old_name.py").rename(src / "new_name.py")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "src" / "new_name.pyi").exists()
         assert not (out / "src" / "old_name.pyi").exists()
 
@@ -612,13 +610,13 @@ class TestBuildStubs:
         pkg = src / "pkg"
         pkg.mkdir()
         (pkg / "mod.py").write_text("def hello(): pass\n")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "src" / "pkg" / "mod.pyi").exists()
 
         # Remove the whole subpackage; the stub directory should be pruned.
         (pkg / "mod.py").unlink()
         pkg.rmdir()
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert not (out / "src" / "pkg").exists()
 
     def test_does_not_touch_other_source_root(self, tmp_path):
@@ -628,42 +626,41 @@ class TestBuildStubs:
         (src / "foo.py").write_text("def hello(): pass\n")
         (tests / "test_foo.py").write_text("def test_hello(): pass\n")
 
-        build_stubs(src, out)
-        build_stubs(tests, out)
+        build_stubs(src, out, base=tmp_path)
+        build_stubs(tests, out, base=tmp_path)
         assert (out / "src" / "foo.pyi").exists()
         assert (out / "tests" / "test_foo.pyi").exists()
 
         # Rebuilding only `src` must leave the `tests` stub alone.
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "tests" / "test_foo.pyi").exists()
 
     def test_no_op_when_clean(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         # Second build with no source changes should not error and should
         # leave the stub in place.
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         assert (out / "src" / "foo.pyi").exists()
 
     def test_reports_count_on_first_build(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        assert build_stubs(src, out) == 2
+        assert build_stubs(src, out, base=tmp_path) == 2
 
     def test_reports_zero_when_clean(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out)
-        assert build_stubs(src, out) == 0
+        build_stubs(src, out, base=tmp_path)
+        assert build_stubs(src, out, base=tmp_path) == 0
 
 
 class TestBuildStubsCheckMode:
     """build_stubs with check=True must report changes without mutating the tree."""
 
     def _setup(self, tmp_path):
-        os.chdir(tmp_path)
         src = tmp_path / "src"
         src.mkdir()
         out = tmp_path / "stubs"
@@ -672,30 +669,30 @@ class TestBuildStubsCheckMode:
     def test_does_not_write_stub_in_check_mode(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        changes = build_stubs(src, out, check=True)
+        changes = build_stubs(src, out, base=tmp_path, check=True)
         assert changes == 1
         assert not (out / "src" / "foo.pyi").exists()
 
     def test_zero_changes_when_clean(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out)
-        assert build_stubs(src, out, check=True) == 0
+        build_stubs(src, out, base=tmp_path)
+        assert build_stubs(src, out, base=tmp_path, check=True) == 0
 
     def test_detects_stale_stub_content(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         # Simulate a source edit that would change the stub.
         (src / "foo.py").write_text("def hello(name: str) -> str: pass\n")
-        assert build_stubs(src, out, check=True) == 1
+        assert build_stubs(src, out, base=tmp_path, check=True) == 1
 
     def test_detects_orphan_stub_without_removing_it(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        build_stubs(src, out)
+        build_stubs(src, out, base=tmp_path)
         (src / "bar.py").unlink()
-        assert build_stubs(src, out, check=True) == 1
+        assert build_stubs(src, out, base=tmp_path, check=True) == 1
         # Check mode must not mutate the tree — orphan is still there.
         assert (out / "src" / "bar.pyi").exists()

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -157,11 +157,6 @@ class TestExtractStub:
         assert module.functions[0].docstring_excerpt is None
 
     def test_whitespace_only_docstring_yields_none(self):
-        # A whitespace-only docstring is observably a docstring at the
-        # AST level but carries no content. ``ast.get_docstring`` with
-        # the default ``clean=True`` cleans it to an empty string, which
-        # ``_first_sentence`` short-circuits as ``None`` rather than
-        # returning an empty excerpt.
         source = textwrap.dedent("""\
             def whitespace_only():
                 '''   '''
@@ -715,8 +710,6 @@ class TestBuildStubsCheckMode:
 
 
 class TestWriteStubs:
-    """The IO half: writes stubs from a generated dict, prunes orphans."""
-
     def test_writes_stubs(self, tmp_path):
         src = tmp_path / "src"
         src.mkdir()
@@ -729,8 +722,6 @@ class TestWriteStubs:
         assert (out / "src" / "foo.pyi").read_text() == "# stub\n"
 
     def test_check_mode_does_not_write(self, tmp_path):
-        # Symmetric with ``sync_file``'s check-mode contract: report what
-        # would change, mutate nothing.
         src = tmp_path / "src"
         src.mkdir()
         out = tmp_path / "stubs"
@@ -742,12 +733,6 @@ class TestWriteStubs:
         assert not (out / "src" / "foo.pyi").exists()
 
     def test_prunes_orphan_stubs(self, tmp_path):
-        # Pre-existing stub under a subpackage of the source-root
-        # subtree whose source has been removed (modelled here by an
-        # empty stubs dict) should be deleted, and child directories
-        # left empty by the deletion should be pruned. The
-        # source-root stub directory itself is preserved — that's
-        # ``_write_stubs``'s "keep stubs_root itself" contract.
         src = tmp_path / "src"
         src.mkdir()
         out = tmp_path / "stubs"
@@ -758,5 +743,5 @@ class TestWriteStubs:
 
         assert changes == 1
         assert not (out / "src" / "pkg" / "orphan.pyi").exists()
-        assert not (out / "src" / "pkg").exists()  # empty subpackage pruned
-        assert (out / "src").exists()  # source-root stub dir preserved
+        assert not (out / "src" / "pkg").exists()
+        assert (out / "src").exists()


### PR DESCRIPTION
Four follow-on issues from the #76 post-merge sweep. The biggest is making `cli._sync`'s working-directory contract for *reads* explicit; the rest are smaller cleanups in adjacent code.

## `cli._sync` working-directory contract

`_sync` now takes a `root` parameter (defaulting to `Path.cwd()`) and threads the located project root through every project-relative *input*: source-root resolution, instruction-file lookup, and the rel-paths rendered into the namespace map and stubs. Paths configured in `pyproject.toml` now resolve against the directory containing the toml rather than against whatever cwd happens to be, so running `uncoded sync` from a subdirectory now finds the right sources.

Output paths (`.uncoded/namespace.yaml`, `.uncoded/stubs/...`, instruction-file writes, the skill files) still resolve relative to cwd. Bringing those onto the same anchor is a separate, larger concern that touches `sync_skill`'s home-directory model — tracked outside this PR.

## One skip warning per broken file per sync

When a source file fails to parse, `iter_source_files` warns once on stderr and skips it. Before this PR, the namespace-map and stubs pipelines each ran `iter_source_files` separately, producing two identical warnings per broken file per `uncoded sync` invocation. `_sync` now drives a single iteration per source root and feeds both pipelines from that pass; new pure extraction functions (`extract_modules`, `_generate_stubs`) handle the work without re-walking.

## Test hygiene

`tests/test_skill.py`'s 10 bare `os.chdir(tmp_path)` calls become `monkeypatch.chdir(tmp_path)`, so cwd is restored on test teardown including failure. The matching calls in `tests/test_stubs.py` are absorbed by `build_stubs` taking an explicit `base=` and removed entirely.

## `_first_sentence` simplification

The docstring-excerpt extractor in `src/uncoded/stubs.py` collapses to a single regex with two alternatives (sentence boundary or first-line boundary), removing the explicit fallback branch.

Closes #77
Closes #78
Closes #79
Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)