### PR TITLE
[claude] privatise build_stubs and tighten _write_stubs signature

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -113,7 +113,7 @@ src/:
       render_stub:
       _generate_stubs:
       _write_stubs:
-      build_stubs:
+      _build_stubs:
     sync.py:
       sync_file:
       remove_file:

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -69,7 +69,7 @@ def _generate_stubs(files: Iterable[tuple[str, str]]) -> dict[Path, str]:
     """Return a mapping from stub relative paths to rendered stub content."""
     ...
 
-def _write_stubs(stubs: dict[Path, str], source_root: Path, output_dir: Path, base: Path, *, root: Path | None, check: bool) -> int:
+def _write_stubs(*, stubs: dict[Path, str], source_root: Path, output_dir: Path, base: Path, root: Path | None, check: bool) -> int:
     """Write *stubs* under *output_dir* and prune orphans under *source_root*."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -73,7 +73,7 @@ def _write_stubs(stubs: dict[Path, str], source_root: Path, output_dir: Path, ba
     """Write *stubs* under *output_dir* and prune orphans under *source_root*."""
     ...
 
-def build_stubs(source_root: Path, output_dir: Path, base: Path | None, *, root: Path | None, check: bool) -> int:
+def _build_stubs(*, source_root: Path, output_dir: Path, base: Path, check: bool) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans."""
     ...
 

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -169,7 +169,7 @@ class TestRenderStub:
         ...
 
 class TestBuildStubs:
-    """build_stubs writes expected stubs and removes orphans for its source root."""
+    """_build_stubs writes expected stubs and removes orphans for its source root."""
 
     def _setup(self, tmp_path):
         ...
@@ -199,7 +199,7 @@ class TestBuildStubs:
         ...
 
 class TestBuildStubsCheckMode:
-    """build_stubs with check=True must report changes without mutating the tree."""
+    """_build_stubs with check=True must report changes without mutating the tree."""
 
     def _setup(self, tmp_path):
         ...

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -3,7 +3,7 @@
 import textwrap
 from pathlib import Path
 import pytest
-from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, _write_stubs, build_stubs, extract_stub, render_stub
+from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, _build_stubs, _write_stubs, extract_stub, render_stub
 
 class TestExtractStub:
 

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -82,10 +82,10 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     for src_root, files in roots_with_files:
         stubs = _generate_stubs(files)
         changes += _write_stubs(
-            stubs,
-            src_root,
-            DEFAULT_STUBS_OUTPUT,
-            project_root,
+            stubs=stubs,
+            source_root=src_root,
+            output_dir=DEFAULT_STUBS_OUTPUT,
+            base=project_root,
             root=project_root,
             check=check,
         )

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -373,12 +373,12 @@ DEFAULT_STUBS_OUTPUT = Path(".uncoded/stubs")
 
 
 def _write_stubs(
+    *,
     stubs: dict[Path, str],
     source_root: Path,
     output_dir: Path,
     base: Path,
-    *,
-    root: Path | None = None,
+    root: Path | None,
     check: bool,
 ) -> int:
     """Write *stubs* under *output_dir* and prune orphans under *source_root*.

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -446,32 +446,31 @@ def _write_stubs(
     return changes
 
 
-def build_stubs(
-    source_root: Path,
-    output_dir: Path = DEFAULT_STUBS_OUTPUT,
-    base: Path | None = None,
+def _build_stubs(
     *,
-    root: Path | None = None,
-    check: bool = False,
+    source_root: Path,
+    output_dir: Path,
+    base: Path,
+    check: bool,
 ) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans.
 
-    Convenience wrapper around :func:`iter_source_files`,
-    :func:`_generate_stubs`, and :func:`_write_stubs`. Stub paths are
-    rendered relative to *base* (defaulting to cwd), so the rendered
-    ``rel_path`` headers match the project-relative paths that
-    :func:`walk_source` and the namespace map use.
-
-    When ``root`` is provided, ``output_dir`` is treated as relative to
-    ``root`` for filesystem I/O while printed messages remain
-    project-relative.
+    Internal end-to-end helper used by the test suite. Stub paths are
+    rendered relative to *base*, so the rendered ``rel_path`` headers
+    match the project-relative paths that :func:`walk_source` and the
+    namespace map use.
 
     When ``check=True``, the on-disk tree is not mutated; instead,
     prospective writes and removals are reported and counted. Returns
     the number of changes (or prospective changes).
     """
-    if base is None:
-        base = Path.cwd()
     base = base.resolve()
     stubs = _generate_stubs(iter_source_files(source_root, base))
-    return _write_stubs(stubs, source_root, output_dir, base, root=root, check=check)
+    return _write_stubs(
+        stubs=stubs,
+        source_root=source_root,
+        output_dir=output_dir,
+        base=base,
+        root=None,
+        check=check,
+    )

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -9,8 +9,8 @@ from uncoded.stubs import (
     StubFunction,
     StubModule,
     StubParam,
+    _build_stubs,
     _write_stubs,
-    build_stubs,
     extract_stub,
     render_stub,
 )
@@ -631,29 +631,29 @@ class TestBuildStubs:
     def test_writes_expected_stubs(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "foo.pyi").exists()
 
     def test_removes_orphan_stub_when_source_deleted(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "bar.pyi").exists()
 
         (src / "bar.py").unlink()
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "foo.pyi").exists()
         assert not (out / "src" / "bar.pyi").exists()
 
     def test_removes_orphan_stub_when_source_renamed(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "old_name.py").write_text("def hello(): pass\n")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "old_name.pyi").exists()
 
         (src / "old_name.py").rename(src / "new_name.py")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "new_name.pyi").exists()
         assert not (out / "src" / "old_name.pyi").exists()
 
@@ -662,13 +662,13 @@ class TestBuildStubs:
         pkg = src / "pkg"
         pkg.mkdir()
         (pkg / "mod.py").write_text("def hello(): pass\n")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "pkg" / "mod.pyi").exists()
 
         # Remove the whole subpackage; the stub directory should be pruned.
         (pkg / "mod.py").unlink()
         pkg.rmdir()
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert not (out / "src" / "pkg").exists()
 
     def test_does_not_touch_other_source_root(self, tmp_path):
@@ -678,35 +678,41 @@ class TestBuildStubs:
         (src / "foo.py").write_text("def hello(): pass\n")
         (tests / "test_foo.py").write_text("def test_hello(): pass\n")
 
-        build_stubs(src, out, base=tmp_path)
-        build_stubs(tests, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
+        _build_stubs(source_root=tests, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "foo.pyi").exists()
         assert (out / "tests" / "test_foo.pyi").exists()
 
         # Rebuilding only `src` must leave the `tests` stub alone.
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "tests" / "test_foo.pyi").exists()
 
     def test_no_op_when_clean(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         # Second build with no source changes should not error and should
         # leave the stub in place.
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         assert (out / "src" / "foo.pyi").exists()
 
     def test_reports_count_on_first_build(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        assert build_stubs(src, out, base=tmp_path) == 2
+        assert (
+            _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
+            == 2
+        )
 
     def test_reports_zero_when_clean(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out, base=tmp_path)
-        assert build_stubs(src, out, base=tmp_path) == 0
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
+        assert (
+            _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
+            == 0
+        )
 
 
 class TestBuildStubsCheckMode:
@@ -721,31 +727,42 @@ class TestBuildStubsCheckMode:
     def test_does_not_write_stub_in_check_mode(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        changes = build_stubs(src, out, base=tmp_path, check=True)
+        changes = _build_stubs(
+            source_root=src, output_dir=out, base=tmp_path, check=True
+        )
         assert changes == 1
         assert not (out / "src" / "foo.pyi").exists()
 
     def test_zero_changes_when_clean(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out, base=tmp_path)
-        assert build_stubs(src, out, base=tmp_path, check=True) == 0
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
+        assert (
+            _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=True)
+            == 0
+        )
 
     def test_detects_stale_stub_content(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         # Simulate a source edit that would change the stub.
         (src / "foo.py").write_text("def hello(name: str) -> str: pass\n")
-        assert build_stubs(src, out, base=tmp_path, check=True) == 1
+        assert (
+            _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=True)
+            == 1
+        )
 
     def test_detects_orphan_stub_without_removing_it(self, tmp_path):
         src, out = self._setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        build_stubs(src, out, base=tmp_path)
+        _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=False)
         (src / "bar.py").unlink()
-        assert build_stubs(src, out, base=tmp_path, check=True) == 1
+        assert (
+            _build_stubs(source_root=src, output_dir=out, base=tmp_path, check=True)
+            == 1
+        )
         # Check mode must not mutate the tree — orphan is still there.
         assert (out / "src" / "bar.pyi").exists()
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -774,7 +774,14 @@ class TestWriteStubs:
         out = tmp_path / "stubs"
         stubs = {Path("src/foo.pyi"): "# stub\n"}
 
-        changes = _write_stubs(stubs, src, out, tmp_path, check=False)
+        changes = _write_stubs(
+            stubs=stubs,
+            source_root=src,
+            output_dir=out,
+            base=tmp_path,
+            root=None,
+            check=False,
+        )
 
         assert changes == 1
         assert (out / "src" / "foo.pyi").read_text() == "# stub\n"
@@ -785,7 +792,14 @@ class TestWriteStubs:
         out = tmp_path / "stubs"
         stubs = {Path("src/foo.pyi"): "# stub\n"}
 
-        changes = _write_stubs(stubs, src, out, tmp_path, check=True)
+        changes = _write_stubs(
+            stubs=stubs,
+            source_root=src,
+            output_dir=out,
+            base=tmp_path,
+            root=None,
+            check=True,
+        )
 
         assert changes == 1
         assert not (out / "src" / "foo.pyi").exists()
@@ -797,7 +811,14 @@ class TestWriteStubs:
         (out / "src" / "pkg").mkdir(parents=True)
         (out / "src" / "pkg" / "orphan.pyi").write_text("# stale\n")
 
-        changes = _write_stubs({}, src, out, tmp_path, check=False)
+        changes = _write_stubs(
+            stubs={},
+            source_root=src,
+            output_dir=out,
+            base=tmp_path,
+            root=None,
+            check=False,
+        )
 
         assert changes == 1
         assert not (out / "src" / "pkg" / "orphan.pyi").exists()
@@ -815,7 +836,14 @@ class TestWriteStubs:
         out = Path("stubs")
         stubs = {Path("src/foo.pyi"): "# stub\n"}
 
-        changes = _write_stubs(stubs, src, out, tmp_path, root=tmp_path, check=False)
+        changes = _write_stubs(
+            stubs=stubs,
+            source_root=src,
+            output_dir=out,
+            base=tmp_path,
+            root=tmp_path,
+            check=False,
+        )
 
         assert changes == 1
         assert (tmp_path / out / "src" / "foo.pyi").read_text() == "# stub\n"
@@ -833,7 +861,14 @@ class TestWriteStubs:
         (tmp_path / out / "src" / "pkg").mkdir(parents=True)
         (tmp_path / out / "src" / "pkg" / "orphan.pyi").write_text("# stale\n")
 
-        changes = _write_stubs({}, src, out, tmp_path, root=tmp_path, check=False)
+        changes = _write_stubs(
+            stubs={},
+            source_root=src,
+            output_dir=out,
+            base=tmp_path,
+            root=tmp_path,
+            check=False,
+        )
 
         assert changes == 1
         assert not (tmp_path / out / "src" / "pkg" / "orphan.pyi").exists()

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -620,7 +620,7 @@ class TestRenderStub:
 
 
 class TestBuildStubs:
-    """build_stubs writes expected stubs and removes orphans for its source root."""
+    """_build_stubs writes expected stubs and removes orphans for its source root."""
 
     def _setup(self, tmp_path):
         src = tmp_path / "src"
@@ -716,7 +716,7 @@ class TestBuildStubs:
 
 
 class TestBuildStubsCheckMode:
-    """build_stubs with check=True must report changes without mutating the tree."""
+    """_build_stubs with check=True must report changes without mutating the tree."""
 
     def _setup(self, tmp_path):
         src = tmp_path / "src"


### PR DESCRIPTION
## Why

`build_stubs` was shaped like public API — no underscore, full docstring, optional defaults — but had no caller outside the test suite. The shape lied; the function is an internal end-to-end helper used by tests. This PR renames it to `_build_stubs` and tightens its signature to match its actual usage.

While we were in `stubs.py`, we applied the same private-function discipline (keyword-only signature, no defaults at the definition, every argument stated at the call site) to `_write_stubs`, the only other private function in the module.

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)