### PR TITLE
[claude] cli._sync source-root error UX + read_source_roots contract (#88)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -156,7 +156,6 @@ tests/:
       test_falls_back_to_start_name_when_name_missing:
     TestReadSourceRoots:
       test_reads_source_roots:
-      test_raises_if_no_pyproject_toml:
       test_raises_if_no_uncoded_section:
     TestReadInstructionFiles:
       test_returns_default_when_no_pyproject_toml:

--- a/.uncoded/stubs/src/uncoded/config.pyi
+++ b/.uncoded/stubs/src/uncoded/config.pyi
@@ -14,8 +14,8 @@ def read_project_name(start: Path) -> str:
     """Read the project name, falling back to the start-dir name."""
     ...
 
-def read_source_roots(start: Path) -> list[Path]:
-    """Read source roots from ``[tool.uncoded] source-roots`` in ``pyproject.toml``."""
+def read_source_roots(pyproject_path: Path) -> list[Path]:
+    """Read source roots from ``[tool.uncoded] source-roots``."""
     ...
 
 def read_instruction_files(start: Path) -> list[Path]:

--- a/.uncoded/stubs/tests/test_config.pyi
+++ b/.uncoded/stubs/tests/test_config.pyi
@@ -35,9 +35,6 @@ class TestReadSourceRoots:
     def test_reads_source_roots(self, tmp_path):
         ...
 
-    def test_raises_if_no_pyproject_toml(self, tmp_path):
-        ...
-
     def test_raises_if_no_uncoded_section(self, tmp_path):
         ...
 

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -53,7 +53,7 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     project_root = pyproject_path.parent
 
     try:
-        configured_roots = read_source_roots(project_root)
+        configured_roots = read_source_roots(pyproject_path)
     except LookupError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -53,16 +53,19 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     project_root = pyproject_path.parent
 
     try:
-        source_roots = [
-            (project_root / r).resolve() for r in read_source_roots(project_root)
-        ]
+        configured_roots = read_source_roots(project_root)
     except LookupError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+    source_roots = [(project_root / r).resolve() for r in configured_roots]
 
-    for src_root in source_roots:
+    for configured, src_root in zip(configured_roots, source_roots, strict=True):
         if not src_root.is_dir():
-            print(f"Error: {src_root} is not a directory", file=sys.stderr)
+            print(
+                f"Error: source root {configured} is not a directory. "
+                "Check [tool.uncoded] source-roots in pyproject.toml.",
+                file=sys.stderr,
+            )
             return 1
 
     changes = 0

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -57,9 +57,10 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
     except LookupError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    source_roots = [(project_root / r).resolve() for r in configured_roots]
 
-    for configured, src_root in zip(configured_roots, source_roots, strict=True):
+    source_roots: list[Path] = []
+    for configured in configured_roots:
+        src_root = (project_root / configured).resolve()
         if not src_root.is_dir():
             print(
                 f"Error: source root {configured} is not a directory. "
@@ -67,6 +68,7 @@ def _sync(*, root: Path | None = None, check: bool = False) -> int:
                 file=sys.stderr,
             )
             return 1
+        source_roots.append(src_root)
 
     changes = 0
 

--- a/src/uncoded/config.py
+++ b/src/uncoded/config.py
@@ -45,9 +45,10 @@ def read_project_name(start: Path) -> str:
 def read_source_roots(pyproject_path: Path) -> list[Path]:
     """Read source roots from ``[tool.uncoded] source-roots``.
 
-    Reads the section from the given ``pyproject.toml``. Raises
-    :class:`LookupError` if the section is missing. Returns the
-    configured paths as a list of :class:`Path` instances on success.
+    Reads the section from the given ``pyproject.toml`` (which the
+    caller must guarantee exists). Raises :class:`LookupError` if the
+    section is missing. Returns the configured paths as a list of
+    :class:`Path` instances on success.
     """
     with pyproject_path.open("rb") as f:
         data = tomllib.load(f)

--- a/src/uncoded/config.py
+++ b/src/uncoded/config.py
@@ -42,18 +42,14 @@ def read_project_name(start: Path) -> str:
         return base.name
 
 
-def read_source_roots(start: Path) -> list[Path]:
-    """Read source roots from ``[tool.uncoded] source-roots`` in ``pyproject.toml``.
+def read_source_roots(pyproject_path: Path) -> list[Path]:
+    """Read source roots from ``[tool.uncoded] source-roots``.
 
-    ``start`` is the directory the upward walk begins from.
+    Reads the section from the given ``pyproject.toml``. Raises
+    :class:`LookupError` if the section is missing. Returns the
+    configured paths as a list of :class:`Path` instances on success.
     """
-    toml_path = find_pyproject_toml(start)
-    if toml_path is None:
-        raise FileNotFoundError(
-            "No pyproject.toml found. Add [tool.uncoded] source-roots to configure."
-        )
-
-    with toml_path.open("rb") as f:
+    with pyproject_path.open("rb") as f:
         data = tomllib.load(f)
 
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,10 @@ class TestSyncApplyMode:
         assert "Error" in capsys.readouterr().err
 
     def test_error_when_source_root_missing(self, tmp_path, monkeypatch, capsys):
+        # The message must (a) report the source-root path as the user
+        # typed it in [tool.uncoded] source-roots, not the resolved
+        # absolute path (which leaks the developer's filesystem layout),
+        # and (b) include a recovery hint pointing at the config key.
         (tmp_path / "pyproject.toml").write_text(
             textwrap.dedent(
                 """\
@@ -121,8 +125,13 @@ class TestSyncApplyMode:
             )
         )
         monkeypatch.chdir(tmp_path)
+
         assert cli._sync() == 1
-        assert "Error" in capsys.readouterr().err
+
+        err = capsys.readouterr().err
+        assert "Error: source root nope is not a directory." in err
+        assert "Check [tool.uncoded] source-roots in pyproject.toml." in err
+        assert str(tmp_path) not in err
 
     def test_error_when_uncoded_section_missing(self, tmp_path, monkeypatch, capsys):
         # User has pyproject.toml but no [tool.uncoded] section. The

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,9 +104,18 @@ class TestSyncApplyMode:
         assert instruction_lines == ["Updated AGENTS.md"]
 
     def test_error_when_no_pyproject_toml(self, tmp_path, monkeypatch, capsys):
+        # Pins the problem statement, the recovery hint pointing at
+        # [tool.uncoded] source-roots, and the absence of any absolute
+        # path leak (this site's message has no path today; pinning
+        # the absence guards against future regressions).
         monkeypatch.chdir(tmp_path)
+
         assert cli._sync() == 1
-        assert "Error" in capsys.readouterr().err
+
+        err = capsys.readouterr().err
+        assert "Error: No pyproject.toml found." in err
+        assert "Add [tool.uncoded] source-roots to configure." in err
+        assert str(tmp_path) not in err
 
     def test_error_when_source_root_missing(self, tmp_path, monkeypatch, capsys):
         # The message must (a) report the source-root path as the user

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,20 +45,16 @@ class TestReadProjectName:
 
 class TestReadSourceRoots:
     def test_reads_source_roots(self, tmp_path):
-        (tmp_path / "pyproject.toml").write_text(
-            '[tool.uncoded]\nsource-roots = ["src", "tests"]\n'
-        )
-        roots = read_source_roots(start=tmp_path)
+        pyproject_path = tmp_path / "pyproject.toml"
+        pyproject_path.write_text('[tool.uncoded]\nsource-roots = ["src", "tests"]\n')
+        roots = read_source_roots(pyproject_path=pyproject_path)
         assert roots == [Path("src"), Path("tests")]
 
-    def test_raises_if_no_pyproject_toml(self, tmp_path):
-        with pytest.raises(FileNotFoundError):
-            read_source_roots(start=tmp_path)
-
     def test_raises_if_no_uncoded_section(self, tmp_path):
-        (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n")
+        pyproject_path = tmp_path / "pyproject.toml"
+        pyproject_path.write_text("[tool.ruff]\n")
         with pytest.raises(LookupError) as excinfo:
-            read_source_roots(start=tmp_path)
+            read_source_roots(pyproject_path=pyproject_path)
         # KeyError would be wrong: its __str__ wraps the message in single
         # quotes, which surfaces as "Error: 'No [tool.uncoded] ...'" in
         # the CLI's f-string. LookupError is the parent type that


### PR DESCRIPTION
Closes #88.

## Summary

GH88 surfaced three configuration-error sites in `cli._sync` with three different idioms. Rather than unify them under a single contract (which would add structure for symmetry, not for users), this PR resolves the tangle by:

- **Polishing the third site's UX** so it matches the other two: project-relative path (no absolute-path leak), recovery hint pointing at `[tool.uncoded] source-roots`.
- **Removing a duplicate `pyproject.toml` walk** between `cli._sync` and `read_source_roots`. `read_source_roots` now takes the located `pyproject_path` directly. This also dissolves a "dead" `FileNotFoundError` branch that was unreachable at runtime but load-bearing for the type checker — both go away in one move, no `# ty: ignore`/`cast`/`assert` needed.

The remaining signature asymmetry across the three readers (`start: Path` for `read_project_name` and `read_instruction_files`, `pyproject_path: Path` for `read_source_roots`) reflects a real contract distinction: the first two have a defined fallback when no `pyproject.toml` is found; the third does not.

## Changes

- `src/uncoded/cli.py`: third error message now uses the configured (project-relative) path and includes a recovery hint; passes `pyproject_path` to `read_source_roots`.
- `src/uncoded/config.py`: `read_source_roots(pyproject_path: Path) -> list[Path]` — opens the toml directly; raises `LookupError` only on missing `[tool.uncoded] source-roots`.
- `tests/test_cli.py`: tightens `test_error_when_source_root_missing` to assert problem statement, recovery hint, and that the absolute `tmp_path` doesn't appear in stderr.
- `tests/test_config.py`: `TestReadSourceRoots` updated to pass `pyproject_path`; `test_raises_if_no_pyproject_toml` removed (the contract no longer exists).
- `.uncoded/`: index regenerated to reflect the signature and test changes.

## Test plan

- [x] `uvx ruff check src tests` — passes
- [x] `uvx ruff format --check src tests` — passes
- [x] `uvx ty check src tests` — passes
- [x] `uv run pytest` — 203 passed (was 204; one fewer because the unreachable-branch test was removed)
- [x] `uv run uncoded check` — clean