### PR TITLE
[claude] one project-anchor name across reads, writes, and prose (#99)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -12,7 +12,6 @@ src/:
     __init__.py:
       __version__:
     cli.py:
-      DEFAULT_MAP_OUTPUT:
       _sync:
       main:
     config.py:
@@ -69,7 +68,6 @@ src/:
       sync_skill:
     stubs.py:
       VALUE_WIDTH_CAP:
-      DEFAULT_STUBS_OUTPUT:
       StubParam:
         name:
         annotation:

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -11,10 +11,8 @@ from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
-from uncoded.stubs import DEFAULT_STUBS_OUTPUT, _generate_stubs, _write_stubs
+from uncoded.stubs import _generate_stubs, _write_stubs
 from uncoded.sync import sync_file
-
-DEFAULT_MAP_OUTPUT = Path('.uncoded/namespace.yaml')
 
 def _sync(*, start: Path | None, check: bool) -> int:
     """Sync (or verify) the namespace map, stub files, and instruction-file sections."""

--- a/.uncoded/stubs/src/uncoded/extract.pyi
+++ b/.uncoded/stubs/src/uncoded/extract.pyi
@@ -20,7 +20,7 @@ def extract_module(source: str, rel_path: str) -> ModuleInfo:
     """Parse Python source and extract classes, functions, and constants."""
     ...
 
-def iter_source_files(source_root: Path, base: Path | None) -> Iterator[tuple[str, str]]:
+def iter_source_files(source_root: Path, project_root: Path | None) -> Iterator[tuple[str, str]]:
     """Yield (source_text, rel_path) for every parseable Python file in *source_root*."""
     ...
 
@@ -28,7 +28,7 @@ def extract_modules(files: Iterable[tuple[str, str]]) -> list[ModuleInfo]:
     """Extract a :class:`ModuleInfo` for each file in *files*."""
     ...
 
-def walk_source(source_root: Path, base: Path | None) -> list[ModuleInfo]:
+def walk_source(source_root: Path, project_root: Path | None) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files."""
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -11,7 +11,6 @@ from uncoded.extract import _property_kind, iter_source_files
 from uncoded.sync import remove_file, sync_file
 
 VALUE_WIDTH_CAP = 80
-DEFAULT_STUBS_OUTPUT = Path('.uncoded/stubs')
 
 def _first_sentence(node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module) -> str | None:
     """Return the first sentence, or first line, of a node's docstring."""

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -14,10 +14,8 @@ from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
-from uncoded.stubs import DEFAULT_STUBS_OUTPUT, _generate_stubs, _write_stubs
+from uncoded.stubs import _generate_stubs, _write_stubs
 from uncoded.sync import sync_file
-
-DEFAULT_MAP_OUTPUT = Path(".uncoded/namespace.yaml")
 
 
 def _sync(*, start: Path | None = None, check: bool = False) -> int:
@@ -78,7 +76,10 @@ def _sync(*, start: Path | None = None, check: bool = False) -> int:
     ]
     map_content = render_map(build_map(modules))
     if sync_file(
-        DEFAULT_MAP_OUTPUT, map_content, project_root=project_root, check=check
+        Path(".uncoded/namespace.yaml"),
+        map_content,
+        project_root=project_root,
+        check=check,
     ):
         changes += 1
 
@@ -87,7 +88,7 @@ def _sync(*, start: Path | None = None, check: bool = False) -> int:
         changes += _write_stubs(
             stubs=stubs,
             source_root=src_root,
-            output_dir=DEFAULT_STUBS_OUTPUT,
+            output_dir=Path(".uncoded/stubs"),
             project_root=project_root,
             check=check,
         )

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -69,7 +69,7 @@ def _sync(*, start: Path | None = None, check: bool = False) -> int:
     changes = 0
 
     roots_with_files = [
-        (src_root, list(iter_source_files(src_root, base=project_root)))
+        (src_root, list(iter_source_files(src_root, project_root=project_root)))
         for src_root in source_roots
     ]
 

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -103,11 +103,14 @@ def iter_source_files(
 ) -> Iterator[tuple[str, str]]:
     """Yield (source_text, rel_path) for every parseable Python file in *source_root*.
 
-    Paths are relative to *project_root* (defaults to cwd). Files that fail to
-    parse are skipped with a single ``warning: skipping ...`` line on
-    stderr — centralising the syntax-error decision here lets downstream
-    consumers (``walk_source``, ``_generate_stubs``) trust they only
-    receive parseable source.
+    When ``project_root`` is given, each yielded ``rel_path`` is the
+    file's path relative to ``project_root``; without it, paths are
+    relative to the current working directory.
+
+    Files that fail to parse are skipped with a single ``warning:
+    skipping ...`` line on stderr — centralising the syntax-error
+    decision here lets downstream consumers (``walk_source``,
+    ``_generate_stubs``) trust they only receive parseable source.
     """
     if project_root is None:
         project_root = Path.cwd()
@@ -151,8 +154,10 @@ def walk_source(
 ) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files.
 
-    Paths in the returned ModuleInfo are relative to *project_root* (defaults to
-    cwd), so they can be used directly to open files from the repo root.
+    When ``project_root`` is given, each returned
+    ``ModuleInfo.rel_path`` is the file's path relative to
+    ``project_root``; without it, paths are relative to the current
+    working directory.
 
     Convenience wrapper around :func:`iter_source_files` and
     :func:`extract_modules`. Files with syntax errors are filtered out

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -99,24 +99,24 @@ def extract_module(source: str, rel_path: str) -> ModuleInfo:
 
 
 def iter_source_files(
-    source_root: Path, base: Path | None = None
+    source_root: Path, project_root: Path | None = None
 ) -> Iterator[tuple[str, str]]:
     """Yield (source_text, rel_path) for every parseable Python file in *source_root*.
 
-    Paths are relative to *base* (defaults to cwd). Files that fail to
+    Paths are relative to *project_root* (defaults to cwd). Files that fail to
     parse are skipped with a single ``warning: skipping ...`` line on
     stderr — centralising the syntax-error decision here lets downstream
     consumers (``walk_source``, ``_generate_stubs``) trust they only
     receive parseable source.
     """
-    if base is None:
-        base = Path.cwd()
+    if project_root is None:
+        project_root = Path.cwd()
 
     source_root = source_root.resolve()
-    base = base.resolve()
+    project_root = project_root.resolve()
 
     for py_file in sorted(source_root.rglob("*.py")):
-        rel_path = str(py_file.relative_to(base))
+        rel_path = str(py_file.relative_to(project_root))
         source = py_file.read_text()
         try:
             ast.parse(source, rel_path)
@@ -146,10 +146,12 @@ def extract_modules(files: Iterable[tuple[str, str]]) -> list[ModuleInfo]:
     return modules
 
 
-def walk_source(source_root: Path, base: Path | None = None) -> list[ModuleInfo]:
+def walk_source(
+    source_root: Path, project_root: Path | None = None
+) -> list[ModuleInfo]:
     """Walk a source root and extract symbols from all Python files.
 
-    Paths in the returned ModuleInfo are relative to *base* (defaults to
+    Paths in the returned ModuleInfo are relative to *project_root* (defaults to
     cwd), so they can be used directly to open files from the repo root.
 
     Convenience wrapper around :func:`iter_source_files` and
@@ -157,4 +159,4 @@ def walk_source(source_root: Path, base: Path | None = None) -> list[ModuleInfo]
     by ``iter_source_files`` (which emits a stderr warning naming the
     offending file).
     """
-    return extract_modules(iter_source_files(source_root, base))
+    return extract_modules(iter_source_files(source_root, project_root))

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -168,9 +168,11 @@ def sync_instruction_file(
     When ``check=True``, reports a prospective change without touching disk.
     Returns ``True`` if a write was (or would be) performed.
 
-    When ``project_root`` is provided, ``path`` is resolved against
-    ``project_root`` for filesystem I/O while the printed message remains
-    ``path`` for project-relative display.
+    When ``project_root`` is given, the file is written to
+    ``project_root / path``. The log line still names ``path`` as given,
+    so messages stay project-relative regardless of where the caller is
+    running from. If ``path`` is absolute, it's used as-is and
+    ``project_root`` has no effect.
     """
     section = generate_section()
     target = project_root / path if project_root is not None else path

--- a/src/uncoded/skill.py
+++ b/src/uncoded/skill.py
@@ -383,10 +383,10 @@ others raise, for the same kind of operation.</flag>
 def sync_skill(*, project_root: Path | None = None, check: bool) -> bool:
     """Write the coherence-review skill file to all supported agent locations.
 
-    When ``project_root`` is provided, the configured output paths are
-    resolved against ``project_root`` for filesystem I/O while printed
-    messages remain project-relative. Without ``project_root``, paths
-    resolve against the current working directory.
+    When ``project_root`` is given, the skill files are written under
+    ``project_root``. Log lines still name each configured path as
+    given, so messages stay project-relative regardless of where the
+    caller is running from.
     """
     results = [
         sync_file(path, _SKILL_CONTENT, project_root=project_root, check=check)

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -369,9 +369,6 @@ def _generate_stubs(files: Iterable[tuple[str, str]]) -> dict[Path, str]:
     return result
 
 
-DEFAULT_STUBS_OUTPUT = Path(".uncoded/stubs")
-
-
 def _write_stubs(
     *,
     stubs: dict[Path, str],

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -383,8 +383,10 @@ def _write_stubs(
     rendered content; typically the return value of
     :func:`_generate_stubs`.
 
-    Stubs are written under ``project_root``; log lines stay
-    project-relative. ``project_root`` must already be resolved.
+    Each stub is written to ``project_root / output_dir / <rel>``. Log
+    lines still name each path as given, so messages stay
+    project-relative regardless of where the caller is running from.
+    ``project_root`` must already be resolved.
 
     Orphan cleanup walks the subtree under ``project_root`` that
     mirrors ``source_root``. ``source_root`` must therefore live under
@@ -448,10 +450,11 @@ def _build_stubs(
 ) -> int:
     """Sync stub files for all symbols under source_root, removing any orphans.
 
-    Internal end-to-end helper used by the test suite. Stub paths are
-    rendered relative to *project_root*, so the rendered ``rel_path``
-    headers match the project-relative paths that :func:`walk_source`
-    and the namespace map use.
+    Internal end-to-end helper used by the test suite. ``project_root``
+    is the anchor for both ends of the pipeline: source paths are made
+    relative to it (so each stub's rendered ``rel_path`` header matches
+    :func:`walk_source` and the namespace map), and each stub is
+    written to ``project_root / output_dir / <rel>``.
 
     When ``check=True``, the on-disk tree is not mutated; instead,
     prospective writes and removals are reported and counted. Returns

--- a/src/uncoded/sync.py
+++ b/src/uncoded/sync.py
@@ -63,7 +63,8 @@ def remove_file(
     When ``project_root`` is given, the file removed is
     ``project_root / path``. The log line still names ``path`` as given,
     so messages stay project-relative regardless of where the caller is
-    running from.
+    running from. If ``path`` is absolute, it's used as-is and
+    ``project_root`` has no effect.
     """
     target = project_root / path if project_root is not None else path
     if not target.exists():

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -118,7 +118,7 @@ class TestExtractModule:
         pkg.mkdir(parents=True)
         (pkg / "__init__.py").write_text('__version__ = "1.0"\n')
 
-        modules = walk_source(src, base=tmp_path)
+        modules = walk_source(src, project_root=tmp_path)
 
         rel_paths = [m.rel_path for m in modules]
         assert "src/mypackage/__init__.py" in rel_paths
@@ -225,7 +225,7 @@ class TestWalkSource:
         (pkg / "_internal.py").write_text("def helper(): pass\n")
         (pkg / "empty.py").write_text("# nothing here\n")
 
-        modules = walk_source(src, base=tmp_path)
+        modules = walk_source(src, project_root=tmp_path)
 
         rel_paths = [m.rel_path for m in modules]
         assert "src/mypackage/core.py" in rel_paths
@@ -242,7 +242,7 @@ class TestWalkSource:
         (sub / "__init__.py").write_text("")
         (sub / "formatting.py").write_text("def format_output(): pass\n")
 
-        modules = walk_source(src, base=tmp_path)
+        modules = walk_source(src, project_root=tmp_path)
 
         rel_paths = [m.rel_path for m in modules]
         assert "src/mypackage/utils/formatting.py" in rel_paths
@@ -254,7 +254,7 @@ class TestWalkSource:
         (pkg / "__init__.py").write_text("def create(): pass\n")
         (pkg / "core.py").write_text("def run(): pass\n")
 
-        modules = walk_source(src, base=tmp_path)
+        modules = walk_source(src, project_root=tmp_path)
 
         rel_paths = [m.rel_path for m in modules]
         assert "src/mypackage/__init__.py" in rel_paths
@@ -267,7 +267,7 @@ class TestWalkSource:
         (pkg / "__init__.py").write_text("")
         (pkg / "core.py").write_text("def run(): pass\n")
 
-        modules = walk_source(src, base=tmp_path)
+        modules = walk_source(src, project_root=tmp_path)
 
         rel_paths = [m.rel_path for m in modules]
         assert not any("__init__.py" in p for p in rel_paths)
@@ -280,7 +280,7 @@ class TestWalkSource:
         (pkg / "good.py").write_text("def works(): pass\n")
         (pkg / "bad.py").write_text("def broken(:\n")
 
-        modules = walk_source(src, base=tmp_path)
+        modules = walk_source(src, project_root=tmp_path)
 
         rel_paths = [m.rel_path for m in modules]
         assert "src/mypackage/good.py" in rel_paths


### PR DESCRIPTION
## Summary

After #90 collapsed the project-anchor vocabulary on the writer family
(`sync_file`, `remove_file`, `sync_instruction_file`, `sync_skill`,
`_write_stubs` all converged on `project_root`), three residues
remained on the same surface:

- The read-side functions `iter_source_files` and `walk_source` still
  named the same anchor `base`. The CLI call site spelled it
  `iter_source_files(src_root, base=project_root)` — same value,
  different name, on the same call chain.
- Five docstrings described the same `project_root` parameter in at
  least three different voices.
- `DEFAULT_MAP_OUTPUT` and `DEFAULT_STUBS_OUTPUT` were referenced once
  each at single call sites in `_sync`, with a `DEFAULT_` prefix that
  promised a `--map-output` / `--stubs-output` flag that doesn't exist.

#99 framed these three as a recurrence — six prior chips on this
family across #54, #60, #68, #77, #84, #90 — and asked for a single
converged answer rather than three small fixes.

This PR delivers that answer in three commits:

- **read-side rename.** `base` → `project_root` on `iter_source_files`
  and `walk_source`, plus the one CLI call site and six test call
  sites. No logic changes.
- **inline `DEFAULT_` constants.** Drop both module-level constants;
  inline the `Path(...)` literals at the single `_sync` call sites.
  The `DEFAULT_` prefix promised an alternative form that doesn't
  exist; removing the surface is the deletion route.
- **converge `project_root` docstrings.** Rewrite the `project_root`
  paragraph at six sites onto the `sync_file`/`remove_file` voice.
  Adapted where appropriate: read-side functions drop the absolute-
  path edge case (it doesn't apply); `sync_skill` drops it too (no
  `path` parameter, configured outputs are all relative); functions
  with required `project_root` (`_write_stubs`, `_build_stubs`) drop
  the optional framing.

After this, every site on the sync pipeline names the parameter
`project_root`, every docstring describes it the same way, and no
unused-prefix constant rides the surface.

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)