### PR TITLE
[claude] tighten render_stub tests, rename TestExtractModule(s)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -297,6 +297,7 @@ tests/:
       test_constant_bare_annotation_rendered:
       test_type_alias_pep695_rendered:
       test_unannotated_class_attribute_rendered:
+      test_renders_valid_python_for_representative_source:
     TestBuildStubs:
       _setup:
       _build:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -286,7 +286,6 @@ tests/:
       test_async_function_prefix:
       test_function_with_annotations:
       test_class_with_bases:
-      test_class_no_bases:
       test_class_with_no_members_renders_body:
       test_attribute_with_annotation:
       test_method_indented:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -155,7 +155,7 @@ tests/:
       test_reads_configured_list:
       test_empty_list_is_respected:
   test_extract.py:
-    TestExtractModule:
+    TestExtractModuleFromSource:
       test_classes_and_functions:
       test_async_functions_and_methods:
       test_empty_module:
@@ -174,7 +174,7 @@ tests/:
       test_includes_init_with_symbols:
       test_skips_empty_init:
       test_skips_syntax_errors:
-    TestExtractModules:
+    TestExtractModulesFromFiles:
       test_returns_module_info_per_parseable_file:
       test_preserves_source_order:
       test_module_with_only_constants_is_kept:

--- a/.uncoded/stubs/tests/test_extract.pyi
+++ b/.uncoded/stubs/tests/test_extract.pyi
@@ -3,7 +3,7 @@
 import textwrap
 from uncoded.extract import extract_module, extract_modules, iter_source_files
 
-class TestExtractModule:
+class TestExtractModuleFromSource:
     def test_classes_and_functions(self):
         ...
 
@@ -56,7 +56,7 @@ class TestIterAndExtract:
     def test_skips_syntax_errors(self, tmp_path, capsys):
         ...
 
-class TestExtractModules:
+class TestExtractModulesFromFiles:
     def test_returns_module_info_per_parseable_file(self):
         ...
 

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -95,9 +95,6 @@ class TestRenderStub:
     def test_class_with_bases(self):
         ...
 
-    def test_class_no_bases(self):
-        ...
-
     def test_class_with_no_members_renders_body(self):
         ...
 

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -128,6 +128,9 @@ class TestRenderStub:
     def test_unannotated_class_attribute_rendered(self):
         ...
 
+    def test_renders_valid_python_for_representative_source(self):
+        ...
+
 class TestBuildStubs:
     def _setup(self, tmp_path):
         ...

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -3,7 +3,7 @@ import textwrap
 from uncoded.extract import extract_module, extract_modules, iter_source_files
 
 
-class TestExtractModule:
+class TestExtractModuleFromSource:
     def test_classes_and_functions(self):
         source = textwrap.dedent("""\
             class MyClass:
@@ -284,7 +284,7 @@ class TestIterAndExtract:
         assert "SyntaxError" in err
 
 
-class TestExtractModules:
+class TestExtractModulesFromFiles:
     def test_returns_module_info_per_parseable_file(self):
         files = [
             ("def foo(): pass\n", "src/a.py"),

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -472,6 +472,42 @@ class TestRenderStub:
         assert "class Registry:\n    items = []\n" in output
         assert "# L" not in output
 
+    def test_renders_valid_python_for_representative_source(self):
+        source = textwrap.dedent("""\
+            import os
+            from pathlib import Path
+
+            MAX: int = 3
+            TIMEOUT = 30
+            type Ids = list[int]
+
+            def greet(name: str) -> str:
+                return f"hi {name}"
+
+            async def fetch(url: str) -> bytes:
+                return b""
+
+            class Record:
+                name: str
+                value: int
+
+                @property
+                def display(self) -> str:
+                    return self.name
+
+                def save(self) -> None:
+                    pass
+
+            class Sentinel:
+                pass
+
+            class Dog(Animal):
+                pass
+        """)
+        module = extract_stub(source, "pkg/representative.py")
+        output = render_stub(module)
+        compile(output, "pkg/representative.pyi", "exec")
+
 
 class TestBuildStubs:
     """build_stubs writes expected stubs and removes orphans for its source root."""

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -326,7 +326,7 @@ class TestRenderStub:
             rel_path="pkg/mod.py",
             functions=[StubFunction(name="fetch", is_async=True)],
         )
-        assert "async def fetch" in render_stub(module)
+        assert "async def fetch():\n    ...\n" in render_stub(module)
 
     def test_function_with_annotations(self):
         module = StubModule(
@@ -339,21 +339,14 @@ class TestRenderStub:
                 )
             ],
         )
-        assert "def greet(name: str) -> str:" in render_stub(module)
+        assert "def greet(name: str) -> str:\n    ...\n" in render_stub(module)
 
     def test_class_with_bases(self):
         module = StubModule(
             rel_path="pkg/mod.py",
             classes=[StubClass(name="Dog", bases=["Animal"])],
         )
-        assert "class Dog(Animal):" in render_stub(module)
-
-    def test_class_no_bases(self):
-        module = StubModule(
-            rel_path="pkg/mod.py",
-            classes=[StubClass(name="Plain")],
-        )
-        assert "class Plain:" in render_stub(module)
+        assert "class Dog(Animal):\n    ...\n" in render_stub(module)
 
     def test_class_with_no_members_renders_body(self):
         # A class with no attributes and no methods needs an explicit
@@ -376,7 +369,7 @@ class TestRenderStub:
                 )
             ],
         )
-        assert "    name: str" in render_stub(module)
+        assert "class Record:\n    name: str\n" in render_stub(module)
 
     def test_method_indented(self):
         module = StubModule(
@@ -394,7 +387,7 @@ class TestRenderStub:
             ],
         )
         output = render_stub(module)
-        assert "    def bar(self):" in output
+        assert "class Foo:\n    def bar(self):\n        ...\n" in output
 
     def test_ends_with_newline(self):
         module = StubModule(rel_path="pkg/mod.py")
@@ -413,7 +406,7 @@ class TestRenderStub:
         """)
         module = extract_stub(source, "pkg/cfg.py")
         output = render_stub(module)
-        assert "    path: Path" in output
+        assert "class Config:\n    path: Path\n" in output
         assert "def path" not in output
 
     def test_constant_with_value_rendered(self):
@@ -421,7 +414,7 @@ class TestRenderStub:
             rel_path="pkg/mod.py",
             constants=[StubAssignment(name="TIMEOUT", value_source="30")],
         )
-        assert "TIMEOUT = 30" in render_stub(module)
+        assert "TIMEOUT = 30\n" in render_stub(module)
 
     def test_constant_annotated_with_value_rendered(self):
         module = StubModule(
@@ -434,14 +427,14 @@ class TestRenderStub:
                 )
             ],
         )
-        assert "MAX: int = 3" in render_stub(module)
+        assert "MAX: int = 3\n" in render_stub(module)
 
     def test_constant_elided_rendered(self):
         module = StubModule(
             rel_path="pkg/mod.py",
             constants=[StubAssignment(name="BIG", value_source="...")],
         )
-        assert "BIG = ..." in render_stub(module)
+        assert "BIG = ...\n" in render_stub(module)
 
     def test_constant_bare_annotation_rendered(self):
         module = StubModule(
@@ -463,7 +456,7 @@ class TestRenderStub:
                 )
             ],
         )
-        assert "type UserId = int" in render_stub(module)
+        assert "type UserId = int\n" in render_stub(module)
 
     def test_unannotated_class_attribute_rendered(self):
         module = StubModule(
@@ -476,7 +469,7 @@ class TestRenderStub:
             ],
         )
         output = render_stub(module)
-        assert "    items = []" in output
+        assert "class Registry:\n    items = []\n" in output
         assert "# L" not in output
 
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -315,10 +315,9 @@ class TestRenderStub:
             ],
         )
         output = render_stub(module)
-        assert "VALUE = 1" in output
-        assert "def run():\n    ..." in output
-        assert "class Worker:" in output
-        assert "    def work(self):" in output
+        assert "VALUE = 1\n" in output
+        assert "def run():\n    ...\n" in output
+        assert "class Worker:\n    def work(self):\n        ...\n" in output
         assert "# L" not in output
 
     def test_async_function_prefix(self):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -442,7 +442,7 @@ class TestRenderStub:
             constants=[StubAssignment(name="FOO", annotation="int")],
         )
         output = render_stub(module)
-        assert "FOO: int" in output
+        assert "FOO: int\n" in output
         assert "FOO: int = " not in output
 
     def test_type_alias_pep695_rendered(self):


### PR DESCRIPTION
Two maintenance fixes from post-merge sweeps on PRs #108 and #112.

## TestExtractModule vs TestExtractModules (#109)

The two top-level test classes in `tests/test_extract.py` differed only by a trailing `s`, costing reading time during work that moved tests between them. Renamed to `TestExtractModuleFromSource` and `TestExtractModulesFromFiles` — the layered design (single-source transform, filesystem composition, plural transform) is preserved.

Closes #109.

## render_stub test assertions (#113)

`TestRenderStub` defended its output with substring `in` checks that would pass on missing-body, missing-newline, or wrong-indent output — the marker-class bug fixed in #112 shipped because nothing exercised `compile()` on a rendered stub. Two changes:

- Each `TestRenderStub` assertion now pins layout — anchored on newlines and explicit indentation, so a regression in `render_stub` would localise to the affected test.
- A new test, `test_renders_valid_python_for_representative_source`, drives a representative source through `extract_stub` → `render_stub` and asserts the result parses via `compile()`. The source covers every branch in the renderer, including the no-members class branch that prompted #112.

`test_class_no_bases` was consolidated into `test_class_with_no_members_renders_body` — after #112 they tested the same case.

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)