### PR TITLE
[claude] tighten render_stub tests, rename is_pep695_alias

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -78,7 +78,7 @@ src/:
         name:
         annotation:
         value_source:
-        is_type_alias:
+        is_pep695_alias:
       StubClass:
         name:
         bases:

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -68,7 +68,7 @@ class StubAssignment:
     name: str
     annotation: str | None = None
     value_source: str | None = None
-    is_type_alias: bool = False
+    is_pep695_alias: bool = False
 
 class StubClass:
     name: str

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -43,7 +43,7 @@ class StubAssignment:
     name: str
     annotation: str | None = None
     value_source: str | None = None
-    is_type_alias: bool = False
+    is_pep695_alias: bool = False
 
 
 @dataclass
@@ -124,7 +124,7 @@ def _extract_assignment(
         return StubAssignment(
             name=node.name.id,
             value_source=_render_value(node.value),
-            is_type_alias=True,
+            is_pep695_alias=True,
         )
 
     if isinstance(node, ast.AnnAssign):
@@ -167,7 +167,6 @@ def _property_attribute(
         name=node.name,
         annotation=ast.unparse(node.returns) if node.returns else None,
         value_source=None,
-        is_type_alias=False,
     )
 
 
@@ -250,7 +249,7 @@ def _render_function(func: StubFunction, indent: str = "") -> list[str]:
 
 def _format_assignment_body(a: StubAssignment) -> str:
     """Render the 'name [: type] [= value]' portion of an assignment."""
-    if a.is_type_alias:
+    if a.is_pep695_alias:
         return f"type {a.name} = {a.value_source}"
     head = f"{a.name}: {a.annotation}" if a.annotation else a.name
     if a.value_source is None:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -155,7 +155,7 @@ class TestExtractStub:
         assert c.name == "MAX_RETRIES"
         assert c.annotation == "int"
         assert c.value_source == "3"
-        assert c.is_type_alias is False
+        assert c.is_pep695_alias is False
 
     def test_constant_unannotated_with_value(self):
         source = textwrap.dedent("""\
@@ -201,7 +201,7 @@ class TestExtractStub:
         assert c.name == "UserId"
         assert c.annotation == "TypeAlias"
         assert c.value_source == "int"
-        assert c.is_type_alias is False
+        assert c.is_pep695_alias is False
 
     def test_type_alias_pep695(self):
         source = textwrap.dedent("""\
@@ -210,7 +210,7 @@ class TestExtractStub:
         module = extract_stub(source, "pkg/mod.py")
         c = module.constants[0]
         assert c.name == "UserId"
-        assert c.is_type_alias is True
+        assert c.is_pep695_alias is True
         assert c.value_source == "int"
 
     def test_tuple_unpacking_skipped(self):
@@ -451,7 +451,7 @@ class TestRenderStub:
                 StubAssignment(
                     name="UserId",
                     value_source="int",
-                    is_type_alias=True,
+                    is_pep695_alias=True,
                 )
             ],
         )

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -295,7 +295,7 @@ class TestRenderStub:
             imports=["import os", "from pathlib import Path"],
         )
         output = render_stub(module)
-        assert "import os\nfrom pathlib import Path" in output
+        assert "import os\nfrom pathlib import Path\n" in output
 
     def test_rendered_stub_has_no_line_range_comments(self):
         module = StubModule(
@@ -485,6 +485,9 @@ class TestRenderStub:
 
             async def fetch(url: str) -> bytes:
                 return b""
+
+            def build(*args: str, **kwargs: int) -> None:
+                pass
 
             class Record:
                 name: str


### PR DESCRIPTION
Two small clean-ups on the stub rendering surface.

PR #114 tightened TestRenderStub assertions but two cases slipped through. `test_imports_rendered` still asserts a substring without the trailing-newline anchor every other module-level pin in the class uses. The smoke source in `test_renders_valid_python_for_representative_source` covers every other rendering branch but skips varargs (`*args`) and kwargs (`**kwargs`). Both are closed here.

`StubAssignment.is_type_alias` is True only for PEP 695 aliases (`type X = int`). Classic `X: TypeAlias = int` carries the alias-ness in its `annotation` field and renders through the standard `name: annotation = value` path. The flag's actual job is narrower than its name — it signals PEP 695-ness so `_format_assignment_body` emits the `type` keyword prefix. The new name matches the semantics.

The redundant `is_type_alias=False` kwarg in `_property_attribute` was dropped at the same time. The dataclass default was already False. After the rename, the kwarg reads as noise: a property is by construction not a PEP 695 alias.

Closes #115
Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)