### PR TITLE
[claude] tighten _render_param coverage, drop redundant kwarg (#118, #119)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -284,7 +284,7 @@ tests/:
       test_imports_rendered:
       test_rendered_stub_has_no_line_range_comments:
       test_async_function_prefix:
-      test_function_with_annotations:
+      test_render_param_covers_input_kind:
       test_class_with_bases:
       test_class_with_no_members_renders_body:
       test_attribute_with_annotation:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -285,6 +285,7 @@ tests/:
       test_rendered_stub_has_no_line_range_comments:
       test_async_function_prefix:
       test_render_param_covers_input_kind:
+      test_return_annotation_rendered:
       test_class_with_bases:
       test_class_with_no_members_renders_body:
       test_attribute_with_annotation:

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -89,7 +89,7 @@ class TestRenderStub:
     def test_async_function_prefix(self):
         ...
 
-    def test_function_with_annotations(self):
+    def test_render_param_covers_input_kind(self, params, expected):
         ...
 
     def test_class_with_bases(self):

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -92,6 +92,9 @@ class TestRenderStub:
     def test_render_param_covers_input_kind(self, params, expected):
         ...
 
+    def test_return_annotation_rendered(self):
+        ...
+
     def test_class_with_bases(self):
         ...
 

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -166,7 +166,6 @@ def _property_attribute(
     return StubAssignment(
         name=node.name,
         annotation=ast.unparse(node.returns) if node.returns else None,
-        value_source=None,
     )
 
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -327,18 +327,57 @@ class TestRenderStub:
         )
         assert "async def fetch():\n    ...\n" in render_stub(module)
 
-    def test_function_with_annotations(self):
+    @pytest.mark.parametrize(
+        "params,expected",
+        [
+            pytest.param(
+                [StubParam("x")],
+                "def f(x):",
+                id="regular_positional_bare",
+            ),
+            pytest.param(
+                [StubParam("x", "str")],
+                "def f(x: str):",
+                id="regular_positional_annotated",
+            ),
+            pytest.param(
+                [StubParam("*args")],
+                "def f(*args):",
+                id="varargs_bare",
+            ),
+            pytest.param(
+                [StubParam("*args", "str")],
+                "def f(*args: str):",
+                id="varargs_annotated",
+            ),
+            pytest.param(
+                [StubParam("**kwargs")],
+                "def f(**kwargs):",
+                id="kwargs_bare",
+            ),
+            pytest.param(
+                [StubParam("**kwargs", "int")],
+                "def f(**kwargs: int):",
+                id="kwargs_annotated",
+            ),
+            pytest.param(
+                [StubParam("/")],
+                "def f(/):",
+                id="positional_only_separator",
+            ),
+            pytest.param(
+                [StubParam("*")],
+                "def f(*):",
+                id="keyword_only_separator",
+            ),
+        ],
+    )
+    def test_render_param_covers_input_kind(self, params, expected):
         module = StubModule(
             rel_path="pkg/mod.py",
-            functions=[
-                StubFunction(
-                    name="greet",
-                    params=[StubParam("name", "str")],
-                    return_annotation="str",
-                )
-            ],
+            functions=[StubFunction(name="f", params=params)],
         )
-        assert "def greet(name: str) -> str:\n    ...\n" in render_stub(module)
+        assert expected in render_stub(module)
 
     def test_class_with_bases(self):
         module = StubModule(
@@ -487,6 +526,12 @@ class TestRenderStub:
                 return b""
 
             def build(*args: str, **kwargs: int) -> None:
+                pass
+
+            def collect(*args, **kwargs):
+                pass
+
+            def separators(x, /, *, y):
                 pass
 
             class Record:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -379,6 +379,13 @@ class TestRenderStub:
         )
         assert expected in render_stub(module)
 
+    def test_return_annotation_rendered(self):
+        module = StubModule(
+            rel_path="pkg/mod.py",
+            functions=[StubFunction(name="f", return_annotation="str")],
+        )
+        assert "def f() -> str:" in render_stub(module)
+
     def test_class_with_bases(self):
         module = StubModule(
             rel_path="pkg/mod.py",


### PR DESCRIPTION
Closes #118.
Closes #119.

## Why

#118 reports that `_render_param` keeps gaining input shapes (varargs, kwargs, the `/` and `*` separators) without the tests catching the gaps. Each prior pass closed the shapes it noticed and moved on. The fix is to name the contract once and enforce it on the remaining shapes, so the next added shape is visible if it has no test row.

#119 is the same kind of redundant-default kwarg as #116 — `_property_attribute` was the last `StubAssignment(...)` call site asserting a field default the dataclass already guarantees.

## What changes

- `TestRenderStub` now has `test_render_param_covers_input_kind`, a parametrised test with one row per shape `_render_param` can receive: regular positional (bare and annotated), varargs (bare and annotated), kwargs (bare and annotated), positional-only `/`, keyword-only `*`. A new shape without a row is visible.
- The representative smoke source in `test_renders_valid_python_for_representative_source` now exercises the four shapes it was missing at compile level: bare `*args`, bare `**kwargs`, `/`, and `*`.
- A separate focused test pins `_render_function`'s `-> {return_annotation}` rendering — restored after the replaced `test_function_with_annotations` was doing double duty.
- `_property_attribute` no longer passes `value_source=None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)