### PR TITLE
[claude] tighten _extract_params test coverage (#122)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -264,6 +264,7 @@ tests/:
       test_class_with_bases:
       test_class_no_bases:
       test_kwargs_and_varargs:
+      test_extract_params_covers_input_kind:
       test_imports_collected:
       test_syntax_error_raises:
       test_source_order_preserved:

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -31,6 +31,9 @@ class TestExtractStub:
     def test_kwargs_and_varargs(self):
         ...
 
+    def test_extract_params_covers_input_kind(self, source, expected):
+        ...
+
     def test_imports_collected(self):
         ...
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -117,6 +117,66 @@ class TestExtractStub:
             StubParam("**kwargs", "int"),
         ]
 
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            pytest.param(
+                "def f(x): pass\n",
+                [StubParam("x")],
+                id="regular_positional_bare",
+            ),
+            pytest.param(
+                "def f(x: str): pass\n",
+                [StubParam("x", "str")],
+                id="regular_positional_annotated",
+            ),
+            pytest.param(
+                "def f(*args): pass\n",
+                [StubParam("*args")],
+                id="vararg_bare",
+            ),
+            pytest.param(
+                "def f(*args: str): pass\n",
+                [StubParam("*args", "str")],
+                id="vararg_annotated",
+            ),
+            pytest.param(
+                "def f(**kwargs): pass\n",
+                [StubParam("**kwargs")],
+                id="kwarg_bare",
+            ),
+            pytest.param(
+                "def f(**kwargs: int): pass\n",
+                [StubParam("**kwargs", "int")],
+                id="kwarg_annotated",
+            ),
+            pytest.param(
+                "def f(x, /): pass\n",
+                [StubParam("x"), StubParam("/")],
+                id="posonly_bare",
+            ),
+            pytest.param(
+                "def f(x: str, /): pass\n",
+                [StubParam("x", "str"), StubParam("/")],
+                id="posonly_annotated",
+            ),
+            pytest.param(
+                "def f(*, x): pass\n",
+                [StubParam("*"), StubParam("x")],
+                id="kwonly_bare",
+            ),
+            pytest.param(
+                "def f(*, x: str): pass\n",
+                [StubParam("*"), StubParam("x", "str")],
+                id="kwonly_annotated",
+            ),
+        ],
+    )
+    def test_extract_params_covers_input_kind(self, source, expected):
+        module = extract_stub(source, "pkg/f.py")
+        f = module.functions[0]
+        assert f.params == expected
+
     def test_imports_collected(self):
         source = textwrap.dedent("""\
             import os

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -85,9 +85,7 @@ class TestExtractStub:
             ("value", "int"),
             ("_internal", "float"),
         ]
-        assert len(cls.methods) == 2
-        assert cls.methods[0].name == "save"
-        assert cls.methods[1].name == "_validate"
+        assert [m.name for m in cls.methods] == ["save", "_validate"]
 
     def test_class_with_bases(self):
         source = textwrap.dedent("""\

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -112,8 +112,10 @@ class TestExtractStub:
         """)
         module = extract_stub(source, "pkg/build.py")
         f = module.functions[0]
-        assert StubParam("*args", "str") in f.params
-        assert StubParam("**kwargs", "int") in f.params
+        assert f.params == [
+            StubParam("*args", "str"),
+            StubParam("**kwargs", "int"),
+        ]
 
     def test_imports_collected(self):
         source = textwrap.dedent("""\

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -133,22 +133,22 @@ class TestExtractStub:
             pytest.param(
                 "def f(*args): pass\n",
                 [StubParam("*args")],
-                id="vararg_bare",
+                id="varargs_bare",
             ),
             pytest.param(
                 "def f(*args: str): pass\n",
                 [StubParam("*args", "str")],
-                id="vararg_annotated",
+                id="varargs_annotated",
             ),
             pytest.param(
                 "def f(**kwargs): pass\n",
                 [StubParam("**kwargs")],
-                id="kwarg_bare",
+                id="kwargs_bare",
             ),
             pytest.param(
                 "def f(**kwargs: int): pass\n",
                 [StubParam("**kwargs", "int")],
-                id="kwarg_annotated",
+                id="kwargs_annotated",
             ),
             pytest.param(
                 "def f(x, /): pass\n",


### PR DESCRIPTION
Closes #122.

`tests/test_stubs.py::TestExtractStub::test_kwargs_and_varargs` was the only collection assertion in `TestExtractStub` using membership (`in`) — a regression in `_extract_params` that produced extra, reordered, or duplicated `StubParam`s in the varargs/kwargs case would have slipped past. Tightened to full-list equality, matching the rest of the class.

While there, the recurrence pattern across #113, #118, and #122 (test-contract laxity in `test_stubs.py`) pointed at an unnamed contract on the extraction side. #118 named it on the rendering side — every `_render_param` branch is defended by a focused pin via `test_render_param_covers_input_kind`. This PR adds the parallel on the extraction side: `test_extract_params_covers_input_kind` walks every branch of `_extract_params` (regular positional, varargs, kwargs, posonly `/`, keyword-only `*`, kwonly) with one parametrize case each, asserting full-list equality on the extracted params. Future branches added to `_extract_params` are now expected to come with their matching case.

Two smaller tidies travel with it: the new test's parametrize IDs are aligned with the rendering-side siblings (`varargs_*`, `kwargs_*`), and the methods half of `test_class_with_attributes_and_methods` is tightened to projection equality to match the attributes half within the same test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)