### PR TITLE
[claude] tighten _extract_params test coverage (#125)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -263,7 +263,6 @@ tests/:
       test_class_with_attributes_and_methods:
       test_class_with_bases:
       test_class_no_bases:
-      test_kwargs_and_varargs:
       test_extract_params_covers_input_kind:
       test_imports_collected:
       test_syntax_error_raises:

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -28,9 +28,6 @@ class TestExtractStub:
     def test_class_no_bases(self):
         ...
 
-    def test_kwargs_and_varargs(self):
-        ...
-
     def test_extract_params_covers_input_kind(self, source, expected):
         ...
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -103,18 +103,6 @@ class TestExtractStub:
         module = extract_stub(source, "pkg/plain.py")
         assert module.classes[0].bases == []
 
-    def test_kwargs_and_varargs(self):
-        source = textwrap.dedent("""\
-            def build(*args: str, **kwargs: int) -> None:
-                pass
-        """)
-        module = extract_stub(source, "pkg/build.py")
-        f = module.functions[0]
-        assert f.params == [
-            StubParam("*args", "str"),
-            StubParam("**kwargs", "int"),
-        ]
-
     @pytest.mark.parametrize(
         "source,expected",
         [
@@ -127,6 +115,11 @@ class TestExtractStub:
                 "def f(x: str): pass\n",
                 [StubParam("x", "str")],
                 id="regular_positional_annotated",
+            ),
+            pytest.param(
+                "def f(x: int = 0): pass\n",
+                [StubParam("x", "int")],
+                id="defaults_dropped_positional",
             ),
             pytest.param(
                 "def f(*args): pass\n",
@@ -167,6 +160,21 @@ class TestExtractStub:
                 "def f(*, x: str): pass\n",
                 [StubParam("*"), StubParam("x", "str")],
                 id="kwonly_annotated",
+            ),
+            pytest.param(
+                "def f(*, x: int = 0): pass\n",
+                [StubParam("*"), StubParam("x", "int")],
+                id="defaults_dropped_kwonly",
+            ),
+            pytest.param(
+                "def f(*args, x): pass\n",
+                [StubParam("*args"), StubParam("x")],
+                id="vararg_with_kwonly",
+            ),
+            pytest.param(
+                "def f(*args, **kwargs): pass\n",
+                [StubParam("*args"), StubParam("**kwargs")],
+                id="vararg_with_kwarg",
             ),
         ],
     )
@@ -599,6 +607,9 @@ class TestRenderStub:
                 pass
 
             def separators(x, /, *, y):
+                pass
+
+            def configure(retries: int = 3) -> None:
                 pass
 
             class Record:


### PR DESCRIPTION
Closes #125.

Four new parametrize cases in `test_extract_params_covers_input_kind` pin two coverage gaps:

- `vararg_with_kwonly` (`def f(*args, x): pass`) pins the branch interaction where the vararg branch fires *and* the kwonly loop runs *without* the `*` separator. Existing single-feature cases didn't cover this combination, so a regression wrongly emitting the separator after a vararg or dropping the kwonly args after a vararg would not have been caught.
- `defaults_dropped_positional` and `defaults_dropped_kwonly` pin the "defaults dropped" claim in `_extract_params`'s docstring. The implementation reads neither `args.defaults` nor `args.kw_defaults`; before this change no test caught a regression encoding a default into name or annotation. Compile-smoke does not catch every form because `def f(x: int = 0):` is valid Python.

The legacy `test_kwargs_and_varargs` is deleted. A new bare `vararg_with_kwarg` case (`def f(*args, **kwargs): pass`) takes its place in the parametrize table; annotated-combination coverage is retained via compile-smoke on `def build(*args: str, **kwargs: int)` in the representative source.

The representative source in `test_renders_valid_python_for_representative_source` gains a function with a default (`def configure(retries: int = 3) -> None: pass`), extending compile-smoke coverage of the defaults contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)