### PR TITLE
[claude] relocate cross-module AST helpers; dedupe test helpers (#131, #133)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -350,8 +350,6 @@ tests/:
       test_unannotated_class_attribute_rendered:
       test_renders_valid_python_for_representative_source:
     TestBuildStubs:
-      _setup:
-      _build:
       test_writes_expected_stubs:
       test_removes_orphan_stub_when_source_deleted:
       test_removes_orphan_stub_when_source_renamed:
@@ -362,8 +360,6 @@ tests/:
       test_reports_zero_when_clean:
       test_skips_module_with_no_symbols:
     TestBuildStubsCheckMode:
-      _setup:
-      _build:
       test_does_not_write_stub_in_check_mode:
       test_zero_changes_when_clean:
       test_detects_stale_stub_content:
@@ -375,6 +371,8 @@ tests/:
       test_project_root_anchors_writes_independent_of_cwd:
       test_project_root_anchors_orphan_pruning_independent_of_cwd:
       test_source_root_outside_project_root_skips_cleanup:
+    _setup:
+    _build:
   test_sync.py:
     TestSyncFile:
       test_creates_missing_file:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -11,6 +11,9 @@ src/:
   uncoded/:
     __init__.py:
       __version__:
+    ast_helpers.py:
+      property_kind:
+      assign_target_name:
     body.py:
       BodyNotFound:
       resolve_body:
@@ -36,8 +39,6 @@ src/:
         constants:
         classes:
         functions:
-      property_kind:
-      _assign_target_name:
       extract_module:
       iter_source_files:
       extract_modules:

--- a/.uncoded/stubs/src/uncoded/ast_helpers.pyi
+++ b/.uncoded/stubs/src/uncoded/ast_helpers.pyi
@@ -1,0 +1,9 @@
+# src/uncoded/ast_helpers.py
+
+import ast
+
+def property_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    ...
+
+def assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:
+    ...

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -2,7 +2,7 @@
 
 import ast
 from pathlib import Path
-from uncoded.extract import _assign_target_name, property_kind
+from uncoded.ast_helpers import assign_target_name, property_kind
 
 def resolve_body(name_path: str, in_path: Path) -> str:
     ...

--- a/.uncoded/stubs/src/uncoded/extract.pyi
+++ b/.uncoded/stubs/src/uncoded/extract.pyi
@@ -5,12 +5,7 @@ import sys
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
-
-def property_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
-    ...
-
-def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:
-    ...
+from uncoded.ast_helpers import assign_target_name, property_kind
 
 def extract_module(source: str, rel_path: str) -> ModuleInfo:
     ...

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -4,7 +4,7 @@ import ast
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from uncoded.extract import property_kind
+from uncoded.ast_helpers import property_kind
 from uncoded.sync import remove_file, sync_file
 
 VALUE_WIDTH_CAP = 80

--- a/.uncoded/stubs/tests/test_stubs.pyi
+++ b/.uncoded/stubs/tests/test_stubs.pyi
@@ -6,6 +6,12 @@ import pytest
 from uncoded.extract import iter_source_files
 from uncoded.stubs import StubAssignment, StubClass, StubFunction, StubModule, StubParam, _write_stubs, build_stubs, extract_stub, render_stub
 
+def _setup(tmp_path):
+    ...
+
+def _build(source_root, out, tmp_path, *, check):
+    ...
+
 class TestExtractStub:
     def test_simple_function(self):
         ...
@@ -141,12 +147,6 @@ class TestRenderStub:
         ...
 
 class TestBuildStubs:
-    def _setup(self, tmp_path):
-        ...
-
-    def _build(self, source_root, out, tmp_path, *, check):
-        ...
-
     def test_writes_expected_stubs(self, tmp_path):
         ...
 
@@ -175,12 +175,6 @@ class TestBuildStubs:
         ...
 
 class TestBuildStubsCheckMode:
-    def _setup(self, tmp_path):
-        ...
-
-    def _build(self, source_root, out, tmp_path, *, check):
-        ...
-
     def test_does_not_write_stub_in_check_mode(self, tmp_path):
         ...
 

--- a/src/uncoded/ast_helpers.py
+++ b/src/uncoded/ast_helpers.py
@@ -1,0 +1,30 @@
+"""AST helper functions shared across multiple uncoded modules."""
+
+import ast
+
+
+def property_kind(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> str | None:
+    """Classify a function or method by its property-related decorators.
+
+    Returns "property" for @property, "setter" for @<name>.setter,
+    "deleter" for @<name>.deleter, or None for a plain function or method.
+    """
+    for d in node.decorator_list:
+        if isinstance(d, ast.Name) and d.id == "property":
+            return "property"
+        if isinstance(d, ast.Attribute) and d.attr in ("setter", "deleter"):
+            return d.attr
+    return None
+
+
+def assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:
+    """Return the single-name target of an assignment, or None if not a simple name."""
+    if isinstance(node, ast.AnnAssign):
+        target = node.target
+        return target.id if isinstance(target, ast.Name) else None
+    if len(node.targets) != 1:
+        return None
+    target = node.targets[0]
+    return target.id if isinstance(target, ast.Name) else None

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -3,7 +3,7 @@
 import ast
 from pathlib import Path
 
-from uncoded.extract import _assign_target_name, property_kind
+from uncoded.ast_helpers import assign_target_name, property_kind
 
 
 class BodyNotFound(Exception):
@@ -39,7 +39,7 @@ def resolve_body(name_path: str, in_path: Path) -> str:
         if matches_class or matches_function:
             match = node
         elif isinstance(node, (ast.Assign, ast.AnnAssign)) and tail is None:
-            name = _assign_target_name(node)
+            name = assign_target_name(node)
             if name == head:
                 match = node
         elif isinstance(node, ast.TypeAlias) and tail is None and node.name.id == head:
@@ -72,7 +72,7 @@ def _resolve_class_member(
 
     for node in ast.iter_child_nodes(class_node):
         if isinstance(node, (ast.Assign, ast.AnnAssign)):
-            name = _assign_target_name(node)
+            name = assign_target_name(node)
             if name == member_name:
                 match = node
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -6,6 +6,8 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from uncoded.ast_helpers import assign_target_name, property_kind
+
 
 @dataclass
 class ClassInfo:
@@ -26,33 +28,6 @@ class ModuleInfo:
     functions: list[str] = field(default_factory=list)
 
 
-def property_kind(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
-) -> str | None:
-    """Classify a method by its property-related decorators.
-
-    Returns "property" for @property, "setter" for @<name>.setter,
-    "deleter" for @<name>.deleter, or None for a plain method.
-    """
-    for d in node.decorator_list:
-        if isinstance(d, ast.Name) and d.id == "property":
-            return "property"
-        if isinstance(d, ast.Attribute) and d.attr in ("setter", "deleter"):
-            return d.attr
-    return None
-
-
-def _assign_target_name(node: ast.Assign | ast.AnnAssign) -> str | None:
-    """Return the single-name target of an assignment, or None if not a simple name."""
-    if isinstance(node, ast.AnnAssign):
-        target = node.target
-        return target.id if isinstance(target, ast.Name) else None
-    if len(node.targets) != 1:
-        return None
-    target = node.targets[0]
-    return target.id if isinstance(target, ast.Name) else None
-
-
 def extract_module(source: str, rel_path: str) -> ModuleInfo:
     """Parse Python source and extract classes, functions, and constants."""
     tree = ast.parse(source)
@@ -67,7 +42,7 @@ def extract_module(source: str, rel_path: str) -> ModuleInfo:
             methods: list[str] = []
             for n in ast.iter_child_nodes(node):
                 if isinstance(n, (ast.AnnAssign, ast.Assign)):
-                    name = _assign_target_name(n)
+                    name = assign_target_name(n)
                     if name:
                         attributes.append(name)
                 elif isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -84,7 +59,7 @@ def extract_module(source: str, rel_path: str) -> ModuleInfo:
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             functions.append(node.name)
         elif isinstance(node, (ast.Assign, ast.AnnAssign)):
-            name = _assign_target_name(node)
+            name = assign_target_name(node)
             if name:
                 constants.append(name)
         elif isinstance(node, ast.TypeAlias):

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from uncoded.extract import property_kind
+from uncoded.ast_helpers import property_kind
 from uncoded.sync import remove_file, sync_file
 
 # Width cap for inlining the right-hand side of an assignment. If the unparsed

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -17,6 +17,23 @@ from uncoded.stubs import (
 )
 
 
+def _setup(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    out = tmp_path / "stubs"
+    return src, out
+
+
+def _build(source_root, out, tmp_path, *, check=False):
+    return build_stubs(
+        files=list(iter_source_files(source_root, project_root=tmp_path)),
+        source_root=source_root,
+        output_dir=out,
+        project_root=tmp_path,
+        check=check,
+    )
+
+
 class TestExtractStub:
     def test_simple_function(self):
         source = textwrap.dedent("""\
@@ -650,106 +667,91 @@ class TestRenderStub:
 class TestBuildStubs:
     """build_stubs writes expected stubs and removes orphans for its source root."""
 
-    def _setup(self, tmp_path):
-        src = tmp_path / "src"
-        src.mkdir()
-        out = tmp_path / "stubs"
-        return src, out
-
-    def _build(self, source_root, out, tmp_path, *, check=False):
-        return build_stubs(
-            files=list(iter_source_files(source_root, project_root=tmp_path)),
-            source_root=source_root,
-            output_dir=out,
-            project_root=tmp_path,
-            check=check,
-        )
-
     def test_writes_expected_stubs(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "src" / "foo.pyi").exists()
 
     def test_removes_orphan_stub_when_source_deleted(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "src" / "bar.pyi").exists()
 
         (src / "bar.py").unlink()
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "src" / "foo.pyi").exists()
         assert not (out / "src" / "bar.pyi").exists()
 
     def test_removes_orphan_stub_when_source_renamed(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "old_name.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "src" / "old_name.pyi").exists()
 
         (src / "old_name.py").rename(src / "new_name.py")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "src" / "new_name.pyi").exists()
         assert not (out / "src" / "old_name.pyi").exists()
 
     def test_prunes_empty_directories(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         pkg = src / "pkg"
         pkg.mkdir()
         (pkg / "mod.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "src" / "pkg" / "mod.pyi").exists()
 
         # Remove the whole subpackage; the stub directory should be pruned.
         (pkg / "mod.py").unlink()
         pkg.rmdir()
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert not (out / "src" / "pkg").exists()
 
     def test_does_not_touch_other_source_root(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         tests = tmp_path / "tests"
         tests.mkdir()
         (src / "foo.py").write_text("def hello(): pass\n")
         (tests / "test_foo.py").write_text("def test_hello(): pass\n")
 
-        self._build(src, out, tmp_path)
-        self._build(tests, out, tmp_path)
+        _build(src, out, tmp_path)
+        _build(tests, out, tmp_path)
         assert (out / "src" / "foo.pyi").exists()
         assert (out / "tests" / "test_foo.pyi").exists()
 
         # Rebuilding only `src` must leave the `tests` stub alone.
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "tests" / "test_foo.pyi").exists()
 
     def test_no_op_when_clean(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         # Second build with no source changes should not error and should
         # leave the stub in place.
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert (out / "src" / "foo.pyi").exists()
 
     def test_reports_count_on_first_build(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        assert self._build(src, out, tmp_path) == 2
+        assert _build(src, out, tmp_path) == 2
 
     def test_reports_zero_when_clean(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
-        assert self._build(src, out, tmp_path) == 0
+        _build(src, out, tmp_path)
+        assert _build(src, out, tmp_path) == 0
 
     def test_skips_module_with_no_symbols(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "empty.py").write_text('"""Only a module docstring."""\n')
         (src / "foo.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         assert not (out / "src" / "empty.pyi").exists()
         assert (out / "src" / "foo.pyi").exists()
 
@@ -757,49 +759,34 @@ class TestBuildStubs:
 class TestBuildStubsCheckMode:
     """build_stubs with check=True must report changes without mutating the tree."""
 
-    def _setup(self, tmp_path):
-        src = tmp_path / "src"
-        src.mkdir()
-        out = tmp_path / "stubs"
-        return src, out
-
-    def _build(self, source_root, out, tmp_path, *, check=False):
-        return build_stubs(
-            files=list(iter_source_files(source_root, project_root=tmp_path)),
-            source_root=source_root,
-            output_dir=out,
-            project_root=tmp_path,
-            check=check,
-        )
-
     def test_does_not_write_stub_in_check_mode(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        changes = self._build(src, out, tmp_path, check=True)
+        changes = _build(src, out, tmp_path, check=True)
         assert changes == 1
         assert not (out / "src" / "foo.pyi").exists()
 
     def test_zero_changes_when_clean(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
-        assert self._build(src, out, tmp_path, check=True) == 0
+        _build(src, out, tmp_path)
+        assert _build(src, out, tmp_path, check=True) == 0
 
     def test_detects_stale_stub_content(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         # Simulate a source edit that would change the stub.
         (src / "foo.py").write_text("def hello(name: str) -> str: pass\n")
-        assert self._build(src, out, tmp_path, check=True) == 1
+        assert _build(src, out, tmp_path, check=True) == 1
 
     def test_detects_orphan_stub_without_removing_it(self, tmp_path):
-        src, out = self._setup(tmp_path)
+        src, out = _setup(tmp_path)
         (src / "foo.py").write_text("def hello(): pass\n")
         (src / "bar.py").write_text("def goodbye(): pass\n")
-        self._build(src, out, tmp_path)
+        _build(src, out, tmp_path)
         (src / "bar.py").unlink()
-        assert self._build(src, out, tmp_path, check=True) == 1
+        assert _build(src, out, tmp_path, check=True) == 1
         # Check mode must not mutate the tree — orphan is still there.
         assert (out / "src" / "bar.pyi").exists()
 


### PR DESCRIPTION
Two maintenance items, neither changing behaviour:

**Cross-module AST helpers (#133).** `property_kind` and `_assign_target_name` were defined in `extract.py` but used by `body.py` and `stubs.py` as well. The private one's underscore reached across the module boundary; the public one's docstring read from `extract_module`'s perspective. A prior session (#104) handled the same shape on `_property_kind` by promoting it in place; this one moves both helpers to a new `ast_helpers.py` module where their cross-module audience is implicit in the file location. Future cross-module helpers land in `ast_helpers.py`; helpers staying local to a domain stay in that domain's module.

**Test-helper duplication (#131).** `TestBuildStubs._setup`/`_build` and `TestBuildStubsCheckMode._setup`/`_build` were byte-identical. Promoted to module-level free functions, following the `_init_repo` idiom in `tests/test_cli.py`.

Closes #131
Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)