### PR TITLE
[claude] complete post-cutover toolchain framing (#139, #140)

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -79,6 +79,7 @@ ignored_paths:
 #       The memory name should be meaningful.
 excluded_tools:
 - execute_shell_command
+- find_symbol
 - list_memories
 - read_memory
 - write_memory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,11 @@ uv run pytest tests/test_stubs.py --no-cov
 ## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
-a symbol index over its source code, with
-[Serena](https://github.com/oraios/serena) providing language-server-backed
-tools over that index. The point of this scaffolding is one rule.
+a symbol index over its source code, with two peer tools over that index:
+`uncoded body` for reading a symbol's body, and
+[Serena](https://github.com/oraios/serena) for cross-symbol operations —
+finding references, renaming, editing by symbol, and safe-deleting.
+The point of this scaffolding is one rule.
 
 ### The dispatch rule
 
@@ -160,8 +162,8 @@ deliberately disables. Both calls produce only noise.
 
 ### Where Read, Edit, and grep are still the right tools
 
-The rule is about source navigation by symbol name. Outside that, the
-non-Serena tools stay correct:
+The rule is about source navigation by symbol name. Outside that, Read,
+Edit, and grep stay correct:
 
 - Free-text or pattern search outside source: Markdown, YAML, TOML,
   configs, commit messages, notebook JSON, fixture data.

--- a/README.md
+++ b/README.md
@@ -144,10 +144,11 @@ Agents following that protocol:
 1. Read `.uncoded/namespace.yaml` to orient — every symbol, at a glance.
 2. Read the relevant `.pyi` stubs to understand imports, signatures, constants, and class members.
 3. Run `uncoded body <name_path> --in <relative_path>` when they need implementation detail for a specific symbol.
+4. Use [Serena](https://github.com/oraios/serena) for cross-symbol operations — finding references, renaming, editing by symbol, and safe-deleting. See [Using uncoded with a language server](#using-uncoded-with-a-language-server) for setup.
 
 The split is deliberate: `uncoded` provides a stable map and signature index;
-`uncoded body` resolves the current source body. No grep, no stale
-line-number coordinates, no offset arithmetic.
+`uncoded body` resolves the current source body; Serena handles cross-symbol
+operations. No grep, no stale line-number coordinates, no offset arithmetic.
 
 ## Coherence review
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ Generates three files, tailored for Claude Code:
 
 - **`.mcp.json`** — registers Serena as an MCP server, launched via `uvx`.
 - **`.serena/project.yml`** — picks ty as the backend, ignores `.uncoded/`,
-  and narrows Serena's tool surface (drops `execute_shell_command`, the
-  memory tools, onboarding helpers, and the dashboard opener).
+  and narrows Serena's tool surface (drops `execute_shell_command` and
+  `find_symbol`, the memory tools, onboarding helpers, and the dashboard
+  opener).
 - **`.claude/settings.json`** — enables the Serena server and allowlists
   its navigation and edit tools.
 

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -22,9 +22,11 @@ _SECTION_BODY = """\
 ## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
-a symbol index over its source code, with
-[Serena](https://github.com/oraios/serena) providing language-server-backed
-tools over that index. The point of this scaffolding is one rule.
+a symbol index over its source code, with two peer tools over that index:
+`uncoded body` for reading a symbol's body, and
+[Serena](https://github.com/oraios/serena) for cross-symbol operations —
+finding references, renaming, editing by symbol, and safe-deleting.
+The point of this scaffolding is one rule.
 
 ### The dispatch rule
 
@@ -121,8 +123,8 @@ deliberately disables. Both calls produce only noise.
 
 ### Where Read, Edit, and grep are still the right tools
 
-The rule is about source navigation by symbol name. Outside that, the
-non-Serena tools stay correct:
+The rule is about source navigation by symbol name. Outside that, Read,
+Edit, and grep stay correct:
 
 - Free-text or pattern search outside source: Markdown, YAML, TOML,
   configs, commit messages, notebook JSON, fixture data.

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -21,10 +21,10 @@ automatically:
   offenders, and the allowlist completes the narrowing.
 
 The exclusions in :data:`SERENA_PROJECT_FIELDS` defend in depth alongside
-the prose ``Skip activate_project and check_onboarding_performed`` line
-in ``instruction_files._SECTION_BODY``: the prose tells the agent not to
-call those tools, and the project config drops them from Serena's
-exposed surface so the call cannot land even if the prose is missed.
+``instruction_files._SECTION_BODY``: the prose routes agents toward the
+right tools — and explicitly skips a couple by name — while the project
+config narrows Serena's surface so calls outside that routing cannot land
+even if the prose is missed.
 
 JSON files merge into existing content: pre-existing non-Serena MCP
 servers and permissions are preserved, while the Serena entry itself

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -83,6 +83,7 @@ SERENA_PROJECT_FIELDS = {
     "ignored_paths": [".uncoded"],
     "excluded_tools": [
         "execute_shell_command",
+        "find_symbol",
         "list_memories",
         "read_memory",
         "write_memory",

--- a/tests/test_serena_setup.py
+++ b/tests/test_serena_setup.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).parent.parent
 # SERENA_PROJECT_FIELDS shows up here.
 EXPECTED_EXCLUDED_TOOLS = {
     "execute_shell_command",
+    "find_symbol",
     "list_memories",
     "read_memory",
     "write_memory",


### PR DESCRIPTION
## Summary

PR #138 cut over body retrieval from Serena's `find_symbol` to `uncoded body`, but two parts of the toolchain didn't catch up. The injected dispatch-rule prose still positioned Serena as the primary tool over the index, with `uncoded body` introduced later under Step 3. And `find_symbol` was removed from the Claude Code allowlist but left in Serena's exposed tool surface for any non-Claude MCP client (Codex etc.). This PR closes both gaps.

## Changes

- **`src/uncoded/instruction_files.py`** — the opening of the injected `_SECTION_BODY` now introduces `uncoded body` and Serena as peer tools over the index, with the operation carve named explicitly: `uncoded body` for reading a symbol's body, Serena for cross-symbol operations (find references, rename, edit by symbol, safe-delete). The "non-Serena tools" sentence in the Read/Edit/grep section now names those tools directly so it agrees with the section heading.

- **`README.md`** — the "How agents use it" section gains a fourth numbered item naming Serena's cross-symbol operations, with a pointer to the existing "Using uncoded with a language server" section for setup. The closing paragraph names the full three-way split (index / body / cross-symbol ops).

- **`src/uncoded/serena_setup.py`, `tests/test_serena_setup.py`, `.serena/project.yml`** — `find_symbol` added to `SERENA_PROJECT_FIELDS["excluded_tools"]` and to the dogfooding test fixture, with the existing `.serena/project.yml` updated to match. The exclusion now lands at the project-config layer too, not just the Claude Code allowlist, so non-Claude MCP clients also can't reach it.

Closes #139.
Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)