### PR TITLE
[claude] tidy tool-list prose; bridge uncoded body to Edit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,9 @@ With the map and stub loaded, you have the exact `relative_path` and
 - **Read a symbol's body.** `uncoded body <name_path> --in <relative_path>` —
   prints the symbol's source text to stdout, byte-identical to disk.
   Returns exactly the symbol; no offset arithmetic, no risk of reading
-  too much. Stay on stubs for a wider sweep.
+  too much. Its output is exactly the text `Edit` needs as `old_string`
+  — no extra `Read` required for partial edits. Stay on stubs for a
+  wider sweep.
 
 - **Find callers, or check whether a symbol is dead.**
   `find_referencing_symbols`. Returns every reference resolved by the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,8 @@ With the map and stub loaded, you have the exact `relative_path` and
 - **Read a symbol's body.** `uncoded body <name_path> --in <relative_path>` —
   prints the symbol's source text to stdout, byte-identical to disk.
   Returns exactly the symbol; no offset arithmetic, no risk of reading
-  too much. Its output is exactly the text `Edit` needs as `old_string`
-  — no extra `Read` required for partial edits. Stay on stubs for a
+  too much. Its output has every byte `Edit` needs as `old_string` — no
+  extra `Read` required for partial edits. Stay on stubs for a
   wider sweep.
 
 - **Find callers, or check whether a symbol is dead.**

--- a/README.md
+++ b/README.md
@@ -204,9 +204,7 @@ Generates three files, tailored for Claude Code:
 
 - **`.mcp.json`** — registers Serena as an MCP server, launched via `uvx`.
 - **`.serena/project.yml`** — picks ty as the backend, ignores `.uncoded/`,
-  and narrows Serena's tool surface (drops `execute_shell_command` and
-  `find_symbol`, the memory tools, onboarding helpers, and the dashboard
-  opener).
+  and narrows Serena's tool surface.
 - **`.claude/settings.json`** — enables the Serena server and allowlists
   its navigation and edit tools.
 

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -88,7 +88,9 @@ With the map and stub loaded, you have the exact `relative_path` and
 - **Read a symbol's body.** `uncoded body <name_path> --in <relative_path>` —
   prints the symbol's source text to stdout, byte-identical to disk.
   Returns exactly the symbol; no offset arithmetic, no risk of reading
-  too much. Stay on stubs for a wider sweep.
+  too much. Its output is exactly the text `Edit` needs as `old_string`
+  — no extra `Read` required for partial edits. Stay on stubs for a
+  wider sweep.
 
 - **Find callers, or check whether a symbol is dead.**
   `find_referencing_symbols`. Returns every reference resolved by the

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -88,8 +88,8 @@ With the map and stub loaded, you have the exact `relative_path` and
 - **Read a symbol's body.** `uncoded body <name_path> --in <relative_path>` —
   prints the symbol's source text to stdout, byte-identical to disk.
   Returns exactly the symbol; no offset arithmetic, no risk of reading
-  too much. Its output is exactly the text `Edit` needs as `old_string`
-  — no extra `Read` required for partial edits. Stay on stubs for a
+  too much. Its output has every byte `Edit` needs as `old_string` — no
+  extra `Read` required for partial edits. Stay on stubs for a
   wider sweep.
 
 - **Find callers, or check whether a symbol is dead.**

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -13,7 +13,7 @@ automatically:
   give agents a project-wide view, so Serena's memory-based project
   understanding is redundant and noisy alongside it.
 * ``.claude/settings.json`` — enables the Serena server and allowlists
-  the eight tools so they run without a prompt. This is the file that
+  its tools so they run without a prompt. This is the file that
   finally narrows Serena's active surface to pure LSP operations; the
   YAML's exclusions remove the worst offenders, and the allowlist
   completes the narrowing.

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -8,11 +8,10 @@ automatically:
   it via ``uvx`` on session start, with the web dashboard disabled.
 * ``.serena/project.yml`` — selects ty over Serena's default backend
   (pyright), keeps Serena out of uncoded's generated stubs, and drops
-  the noisier tool surfaces (memory, onboarding, dashboard, shell-exec)
-  that uncoded's index already covers or that have no role in our
-  workflow. uncoded's namespace map and stubs already give agents a
-  project-wide view, so Serena's memory-based project understanding is
-  redundant and noisy alongside it.
+  the noisier tool surfaces that uncoded's index already covers or that
+  have no role in our workflow. uncoded's namespace map and stubs already
+  give agents a project-wide view, so Serena's memory-based project
+  understanding is redundant and noisy alongside it.
 * ``.claude/settings.json`` — enables the Serena server and allowlists
   the eight tools (``initial_instructions`` plus the seven LSP tools —
   reference search, overview, and the edit family) so they run without

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -13,11 +13,10 @@ automatically:
   give agents a project-wide view, so Serena's memory-based project
   understanding is redundant and noisy alongside it.
 * ``.claude/settings.json`` — enables the Serena server and allowlists
-  the eight tools (``initial_instructions`` plus the seven LSP tools —
-  reference search, overview, and the edit family) so they run without
-  a prompt. This is the file that finally narrows Serena's active surface
-  to pure LSP operations; the YAML's exclusions remove the worst
-  offenders, and the allowlist completes the narrowing.
+  the eight tools so they run without a prompt. This is the file that
+  finally narrows Serena's active surface to pure LSP operations; the
+  YAML's exclusions remove the worst offenders, and the allowlist
+  completes the narrowing.
 
 The exclusions in :data:`SERENA_PROJECT_FIELDS` defend in depth alongside
 ``instruction_files._SECTION_BODY``: the prose routes agents toward the


### PR DESCRIPTION
Two small documentation fixes.

## Why

Three parentheticals — in `serena_setup.py`'s module docstring and the README — enumerated tools that `SERENA_PROJECT_FIELDS["excluded_tools"]` and `SERENA_ALLOWED_TOOLS` already list. The prose duplicated the constants in the same file and drifted each time they changed; #47, #139, and #140 each caught instances of that drift. The surrounding sentences already convey design intent without the enumerations. A bare "eight" numeral coupled to `SERENA_ALLOWED_TOOLS` carried the same drift risk and went the same way.

The dispatch rule's "Read a symbol's body" bullet says `uncoded body`'s output is byte-identical to disk, but doesn't say the natural consequence: that output is exactly what `Edit` needs as its `old_string`. Without that bridge, readers still reach for a full-file `Read` to get surrounding context for a partial `Edit`, even though `uncoded body` already gave them every byte.

Closes #142
Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)