### PR TITLE
[claude] add uncoded refs, retire find_referencing_symbols (#111)

### DIFF
--- a/.agents/skills/coherence-review/SKILL.md
+++ b/.agents/skills/coherence-review/SKILL.md
@@ -45,9 +45,8 @@ Verify by reading `.uncoded/namespace.yaml` — if it exists and is non-empty,
 proceed. If not, stop and tell the user to run `uncoded sync` first; the review
 depends on the index.
 
-If Serena MCP tools are available (`mcp__serena__*`), the structural sweep has
-more leverage. The review still works without Serena but will be weaker on
-cross-file reference checks.
+The structural sweep uses `uncoded refs` for cross-file reference checks —
+it ships with uncoded itself and is always available when the index is present.
 
 ## Workflow
 
@@ -165,8 +164,8 @@ during this sweep.
 
 ## Step 4: Structural sweep
 
-Combine the namespace with the import graph and, if available, Serena's
-reference resolution.
+Combine the namespace with the import graph and `uncoded refs` for
+cross-file reference resolution.
 
 **Overgrown public surfaces / god modules.** A module or class whose public
 namespace is much larger than its siblings, or spans obviously different
@@ -192,8 +191,8 @@ Check systematically, not by spot-check:
 2. Cross-reference with stub import sections — any symbol imported by another
    source module is live; remove it from the candidate list. This culls the
    obvious cases cheaply.
-3. For remaining candidates, use Serena's `find_referencing_symbols` to verify.
-   If Serena is unavailable, note findings as lower confidence.
+3. For remaining candidates, use `uncoded refs <name_path> --in <relative_path>`
+   to verify. Empty output confirms zero callers.
 4. Distinguish two sub-cases when reporting:
    - *No callers anywhere* — dead code; highest priority.
    - *Callers only in tests* — the symbol is tested but not used in source;

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,6 @@
   "permissions": {
     "allow": [
       "mcp__serena__initial_instructions",
-      "mcp__serena__find_referencing_symbols",
       "mcp__serena__get_symbols_overview",
       "mcp__serena__rename_symbol",
       "mcp__serena__safe_delete_symbol",

--- a/.claude/skills/coherence-review/SKILL.md
+++ b/.claude/skills/coherence-review/SKILL.md
@@ -45,9 +45,8 @@ Verify by reading `.uncoded/namespace.yaml` — if it exists and is non-empty,
 proceed. If not, stop and tell the user to run `uncoded sync` first; the review
 depends on the index.
 
-If Serena MCP tools are available (`mcp__serena__*`), the structural sweep has
-more leverage. The review still works without Serena but will be weaker on
-cross-file reference checks.
+The structural sweep uses `uncoded refs` for cross-file reference checks —
+it ships with uncoded itself and is always available when the index is present.
 
 ## Workflow
 
@@ -165,8 +164,8 @@ during this sweep.
 
 ## Step 4: Structural sweep
 
-Combine the namespace with the import graph and, if available, Serena's
-reference resolution.
+Combine the namespace with the import graph and `uncoded refs` for
+cross-file reference resolution.
 
 **Overgrown public surfaces / god modules.** A module or class whose public
 namespace is much larger than its siblings, or spans obviously different
@@ -192,8 +191,8 @@ Check systematically, not by spot-check:
 2. Cross-reference with stub import sections — any symbol imported by another
    source module is live; remove it from the candidate list. This culls the
    obvious cases cheaply.
-3. For remaining candidates, use Serena's `find_referencing_symbols` to verify.
-   If Serena is unavailable, note findings as lower confidence.
+3. For remaining candidates, use `uncoded refs <name_path> --in <relative_path>`
+   to verify. Empty output confirms zero callers.
 4. Distinguish two sub-cases when reporting:
    - *No callers anywhere* — dead code; highest priority.
    - *Callers only in tests* — the symbol is tested but not used in source;

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -80,6 +80,7 @@ ignored_paths:
 excluded_tools:
 - execute_shell_command
 - find_symbol
+- find_referencing_symbols
 - list_memories
 - read_memory
 - write_memory

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -85,7 +85,7 @@ src/:
       UnsupportedNamePath:
       resolve_ast_node:
       resolve_name_position:
-      _resolve_ast_node_from_source:
+      resolve_ast_node_from_source:
       _resolve_class_member:
     serena_setup.py:
       _Status:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -333,6 +333,7 @@ tests/:
       test_class_method_shape:
       test_results_are_sorted:
       test_line_and_col_are_one_indexed:
+      test_path_with_spaces_is_not_percent_encoded:
     TestToRelPath:
       test_returns_relative_path_when_under_cwd:
       test_returns_absolute_path_when_outside_cwd:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -15,7 +15,7 @@ src/:
       property_kind:
       assign_target_name:
     body.py:
-      BodyNotFound:
+      SymbolNotFound:
       UnsupportedNamePath:
       resolve_ast_node:
       resolve_name_position:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -19,6 +19,7 @@ src/:
       UnsupportedNamePath:
       resolve_ast_node:
       resolve_body:
+      _resolve_ast_node_from_source:
       _resolve_class_member:
       _extract_body:
     cli.py:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -60,6 +60,20 @@ src/:
         increase_indent:
       build_map:
       render_map:
+    refs.py:
+      TY_VERSION:
+      Reference:
+        path:
+        line:
+        character:
+      query_references:
+      _find_root:
+      _terminate:
+      _run_exchange:
+      _write_message:
+      _read_message:
+      _read_response:
+      _uri_to_path:
     serena_setup.py:
       _Status:
       SERENA_VERSION:
@@ -292,6 +306,26 @@ tests/:
       test_header_appears_at_top:
       test_header_mentions_stub_pointer:
       test_header_does_not_break_yaml_parse:
+  test_refs.py:
+    TestQueryReferences:
+      test_finds_call_sites:
+      test_returns_empty_list_when_no_references:
+    TestRunExchange:
+      test_lsp_error_raises:
+      test_empty_result_list_returns_empty:
+    TestFindRoot:
+      test_returns_pyproject_parent_when_found:
+      test_returns_in_path_parent_when_not_found:
+    TestTerminate:
+      test_kills_on_timeout:
+    TestReadMessage:
+      test_raises_on_closed_stream:
+      test_parses_framed_message:
+    TestReadResponse:
+      test_skips_notifications_until_matching_id:
+    _lsp_stream:
+    _init_response:
+    _shutdown_response:
   test_serena_setup.py:
     REPO_ROOT:
     EXPECTED_EXCLUDED_TOOLS:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -190,6 +190,7 @@ tests/:
       test_unannotated_assignment:
       test_type_alias:
       test_class_method:
+      test_unexpected_node_type_raises_unsupported_name_path:
     TestResolveBodyByteIdentical:
       test_exact_source_returned:
   test_cli.py:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -15,8 +15,13 @@ src/:
       property_kind:
       assign_target_name:
     body.py:
+      NamePath:
+        head:
+        tail:
+        __str__:
       SymbolNotFound:
       UnsupportedNamePath:
+      parse_name_path:
       resolve_ast_node:
       resolve_name_position:
       resolve_body:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -27,6 +27,7 @@ src/:
       _find_project_root:
       _sync:
       _body:
+      _refs:
       main:
     config.py:
       find_pyproject_toml:
@@ -229,6 +230,19 @@ tests/:
       test_stdout_is_exact_body:
       test_unsupported_name_path_exits_one:
       test_missing_in_flag_exits_with_two:
+    TestRefsCommand:
+      test_happy_path_dispatch:
+      test_class_method_form:
+      test_symbol_not_found_exits_one:
+      test_file_not_found_exits_one:
+      test_syntax_error_exits_one:
+      test_works_without_project_root:
+      test_in_path_resolves_relative_to_cwd:
+      test_unsupported_name_path_exits_one:
+      test_missing_in_flag_exits_with_two:
+      test_zero_references_exits_zero_with_empty_stdout:
+      test_multiple_references_prints_sorted:
+      test_lsp_failure_exits_one:
     _init_repo:
   test_config.py:
     TestFindPyprojectToml:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -338,6 +338,7 @@ tests/:
       test_returns_absolute_path_when_outside_cwd:
     TestQueryReferences:
       test_finds_call_sites:
+      test_uvx_not_found_raises_runtime_error:
       test_returns_empty_list_when_no_references:
     TestRunExchange:
       test_lsp_error_raises:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -15,18 +15,7 @@ src/:
       property_kind:
       assign_target_name:
     body.py:
-      NamePath:
-        head:
-        tail:
-        __str__:
-      SymbolNotFound:
-      UnsupportedNamePath:
-      parse_name_path:
-      resolve_ast_node:
-      resolve_name_position:
       resolve_body:
-      _resolve_ast_node_from_source:
-      _resolve_class_member:
       _extract_body:
     cli.py:
       _find_project_root:
@@ -86,6 +75,18 @@ src/:
       _read_message:
       _read_response:
       _uri_to_path:
+    resolver.py:
+      NamePath:
+        head:
+        tail:
+        parse:
+        __str__:
+      SymbolNotFound:
+      UnsupportedNamePath:
+      resolve_ast_node:
+      resolve_name_position:
+      _resolve_ast_node_from_source:
+      _resolve_class_member:
     serena_setup.py:
       _Status:
       SERENA_VERSION:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -341,6 +341,7 @@ tests/:
     TestQueryReferences:
       test_finds_call_sites:
       test_uvx_not_found_raises_runtime_error:
+      test_relative_path_raises_value_error:
       test_returns_empty_list_when_no_references:
     TestRunExchange:
       test_lsp_error_raises:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -17,6 +17,7 @@ src/:
     body.py:
       BodyNotFound:
       UnsupportedNamePath:
+      resolve_ast_node:
       resolve_body:
       _resolve_class_member:
       _extract_body:
@@ -150,6 +151,13 @@ tests/:
       test_empty_leading_segment:
       test_empty_trailing_segment:
       test_empty_middle_segment:
+    TestResolveAstNode:
+      test_returns_function_def_for_top_level_function:
+      test_returns_method_node_for_class_member:
+      test_raises_body_not_found:
+      test_raises_unsupported_name_path:
+      test_file_not_found_propagates:
+      test_syntax_error_propagates:
     TestResolveBodyByteIdentical:
       test_exact_source_returned:
   test_cli.py:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -63,12 +63,18 @@ src/:
     refs.py:
       TY_VERSION:
       Reference:
+        rel_path:
+        line:
+        col:
+      _LSPLocation:
         path:
         line:
         character:
+      find_refs:
       query_references:
       _find_root:
       _terminate:
+      _to_rel_path:
       _run_exchange:
       _write_message:
       _read_message:
@@ -307,6 +313,15 @@ tests/:
       test_header_mentions_stub_pointer:
       test_header_does_not_break_yaml_parse:
   test_refs.py:
+    TestFindRefs:
+      test_returns_empty_for_dead_symbol:
+      test_finds_multiple_references_across_files:
+      test_class_method_shape:
+      test_results_are_sorted:
+      test_line_and_col_are_one_indexed:
+    TestToRelPath:
+      test_returns_relative_path_when_under_cwd:
+      test_returns_absolute_path_when_outside_cwd:
     TestQueryReferences:
       test_finds_call_sites:
       test_returns_empty_list_when_no_references:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -18,6 +18,7 @@ src/:
       BodyNotFound:
       UnsupportedNamePath:
       resolve_ast_node:
+      resolve_name_position:
       resolve_body:
       _resolve_ast_node_from_source:
       _resolve_class_member:
@@ -159,6 +160,15 @@ tests/:
       test_raises_unsupported_name_path:
       test_file_not_found_propagates:
       test_syntax_error_propagates:
+    TestResolveNamePosition:
+      test_function:
+      test_function_decorator_does_not_shift_line:
+      test_async_function:
+      test_class:
+      test_annotated_assignment:
+      test_unannotated_assignment:
+      test_type_alias:
+      test_class_method:
     TestResolveBodyByteIdentical:
       test_exact_source_returned:
   test_cli.py:

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -2,25 +2,36 @@
 
 import ast
 from pathlib import Path
+from typing import NamedTuple
 from uncoded.ast_helpers import assign_target_name, property_kind
 
-def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
+def parse_name_path(s: str) -> NamePath:
     ...
 
-def resolve_name_position(name_path: str, in_path: Path) -> tuple[int, int]:
+def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
     ...
 
-def resolve_body(name_path: str, in_path: Path) -> str:
+def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
     ...
 
-def _resolve_ast_node_from_source(*, name_path: str, source: str, in_path: Path) -> ast.stmt:
+def resolve_body(name_path: NamePath, in_path: Path) -> str:
     ...
 
-def _resolve_class_member(*, name_path: str, in_path: Path, class_node: ast.ClassDef, member_name: str) -> ast.stmt:
+def _resolve_ast_node_from_source(*, name_path: NamePath, source: str, in_path: Path) -> ast.stmt:
+    ...
+
+def _resolve_class_member(*, name_path: NamePath, in_path: Path, class_node: ast.ClassDef, member_name: str) -> ast.stmt:
     ...
 
 def _extract_body(*, node: ast.stmt, lines: list[str]) -> str:
     ...
+
+class NamePath(NamedTuple):
+    head: str
+    tail: str | None = None
+
+    def __str__(self) -> str:
+        ...
 
 class SymbolNotFound(Exception):
     ...

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -10,6 +10,9 @@ def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
 def resolve_body(name_path: str, in_path: Path) -> str:
     ...
 
+def _resolve_ast_node_from_source(*, name_path: str, source: str, in_path: Path) -> ast.stmt:
+    ...
+
 def _resolve_class_member(*, name_path: str, in_path: Path, class_node: ast.ClassDef, member_name: str) -> ast.stmt:
     ...
 

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -2,7 +2,6 @@
 
 import ast
 from pathlib import Path
-from typing import cast
 from uncoded.ast_helpers import assign_target_name, property_kind
 
 def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -22,7 +22,7 @@ def _resolve_class_member(*, name_path: str, in_path: Path, class_node: ast.Clas
 def _extract_body(*, node: ast.stmt, lines: list[str]) -> str:
     ...
 
-class BodyNotFound(Exception):
+class SymbolNotFound(Exception):
     ...
 
 class UnsupportedNamePath(Exception):

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -2,7 +2,7 @@
 
 import ast
 from pathlib import Path
-from uncoded.resolver import NamePath, _resolve_ast_node_from_source
+from uncoded.resolver import NamePath, resolve_ast_node_from_source
 
 def resolve_body(name_path: NamePath, in_path: Path) -> str:
     ...

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -4,10 +4,13 @@ import ast
 from pathlib import Path
 from uncoded.ast_helpers import assign_target_name, property_kind
 
+def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
+    ...
+
 def resolve_body(name_path: str, in_path: Path) -> str:
     ...
 
-def _resolve_class_member(*, name_path: str, in_path: Path, class_node: ast.ClassDef, member_name: str, lines: list[str]) -> str:
+def _resolve_class_member(*, name_path: str, in_path: Path, class_node: ast.ClassDef, member_name: str) -> ast.stmt:
     ...
 
 def _extract_body(*, node: ast.stmt, lines: list[str]) -> str:

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -2,9 +2,13 @@
 
 import ast
 from pathlib import Path
+from typing import cast
 from uncoded.ast_helpers import assign_target_name, property_kind
 
 def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
+    ...
+
+def resolve_name_position(name_path: str, in_path: Path) -> tuple[int, int]:
     ...
 
 def resolve_body(name_path: str, in_path: Path) -> str:

--- a/.uncoded/stubs/src/uncoded/body.pyi
+++ b/.uncoded/stubs/src/uncoded/body.pyi
@@ -2,39 +2,10 @@
 
 import ast
 from pathlib import Path
-from typing import NamedTuple
-from uncoded.ast_helpers import assign_target_name, property_kind
-
-def parse_name_path(s: str) -> NamePath:
-    ...
-
-def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
-    ...
-
-def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
-    ...
+from uncoded.resolver import NamePath, _resolve_ast_node_from_source
 
 def resolve_body(name_path: NamePath, in_path: Path) -> str:
     ...
 
-def _resolve_ast_node_from_source(*, name_path: NamePath, source: str, in_path: Path) -> ast.stmt:
-    ...
-
-def _resolve_class_member(*, name_path: NamePath, in_path: Path, class_node: ast.ClassDef, member_name: str) -> ast.stmt:
-    ...
-
 def _extract_body(*, node: ast.stmt, lines: list[str]) -> str:
-    ...
-
-class NamePath(NamedTuple):
-    head: str
-    tail: str | None = None
-
-    def __str__(self) -> str:
-        ...
-
-class SymbolNotFound(Exception):
-    ...
-
-class UnsupportedNamePath(Exception):
     ...

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -3,7 +3,7 @@
 import argparse
 import sys
 from pathlib import Path
-from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_body
+from uncoded.body import SymbolNotFound, UnsupportedNamePath, resolve_body
 from uncoded.config import find_pyproject_toml, read_instruction_files, read_source_roots
 from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -8,6 +8,7 @@ from uncoded.config import find_pyproject_toml, read_instruction_files, read_sou
 from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
+from uncoded.refs import find_refs
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
 from uncoded.stubs import build_stubs
@@ -20,6 +21,9 @@ def _sync(*, start: Path | None, check: bool) -> int:
     ...
 
 def _body(*, name_path: str, in_path: str) -> int:
+    ...
+
+def _refs(*, name_path: str, in_path: str) -> int:
     ...
 
 def main() -> int:

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -3,7 +3,7 @@
 import argparse
 import sys
 from pathlib import Path
-from uncoded.body import SymbolNotFound, UnsupportedNamePath, resolve_body
+from uncoded.body import SymbolNotFound, UnsupportedNamePath, parse_name_path, resolve_body
 from uncoded.config import find_pyproject_toml, read_instruction_files, read_source_roots
 from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -3,12 +3,13 @@
 import argparse
 import sys
 from pathlib import Path
-from uncoded.body import SymbolNotFound, UnsupportedNamePath, parse_name_path, resolve_body
+from uncoded.body import resolve_body
 from uncoded.config import find_pyproject_toml, read_instruction_files, read_source_roots
 from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.refs import find_refs
+from uncoded.resolver import NamePath, SymbolNotFound, UnsupportedNamePath
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
 from uncoded.stubs import build_stubs

--- a/.uncoded/stubs/src/uncoded/refs.pyi
+++ b/.uncoded/stubs/src/uncoded/refs.pyi
@@ -8,12 +8,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, cast
 from urllib.parse import unquote, urlparse
-from uncoded.body import resolve_name_position
+from uncoded.body import NamePath, resolve_name_position
 from uncoded.config import find_pyproject_toml
 
 TY_VERSION = '0.0.37'
 
-def find_refs(name_path: str, in_path: Path) -> list[Reference]:
+def find_refs(name_path: NamePath, in_path: Path) -> list[Reference]:
     ...
 
 def query_references(in_path: Path, position: tuple[int, int]) -> list[_LSPLocation]:

--- a/.uncoded/stubs/src/uncoded/refs.pyi
+++ b/.uncoded/stubs/src/uncoded/refs.pyi
@@ -7,7 +7,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, cast
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from uncoded.body import resolve_name_position
 from uncoded.config import find_pyproject_toml
 

--- a/.uncoded/stubs/src/uncoded/refs.pyi
+++ b/.uncoded/stubs/src/uncoded/refs.pyi
@@ -1,0 +1,42 @@
+# src/uncoded/refs.py
+
+from __future__ import annotations
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, cast
+from urllib.parse import urlparse
+from uncoded.config import find_pyproject_toml
+
+TY_VERSION = '0.0.37'
+
+def query_references(in_path: Path, position: tuple[int, int]) -> list[Reference]:
+    ...
+
+def _find_root(in_path: Path) -> Path:
+    ...
+
+def _terminate(*, proc: subprocess.Popen[bytes]) -> None:
+    ...
+
+def _run_exchange(*, stdin: IO[bytes], stdout: IO[bytes], in_path: Path, position: tuple[int, int], root: Path) -> list[Reference]:
+    ...
+
+def _write_message(*, stream: IO[bytes], msg: dict) -> None:
+    ...
+
+def _read_message(*, stream: IO[bytes]) -> dict:
+    ...
+
+def _read_response(*, stream: IO[bytes], request_id: int) -> dict:
+    ...
+
+def _uri_to_path(uri: str) -> Path:
+    ...
+
+class Reference:
+    path: Path
+    line: int
+    character: int

--- a/.uncoded/stubs/src/uncoded/refs.pyi
+++ b/.uncoded/stubs/src/uncoded/refs.pyi
@@ -8,8 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, cast
 from urllib.parse import unquote, urlparse
-from uncoded.body import NamePath, resolve_name_position
 from uncoded.config import find_pyproject_toml
+from uncoded.resolver import NamePath, resolve_name_position
 
 TY_VERSION = '0.0.37'
 

--- a/.uncoded/stubs/src/uncoded/refs.pyi
+++ b/.uncoded/stubs/src/uncoded/refs.pyi
@@ -8,11 +8,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, cast
 from urllib.parse import urlparse
+from uncoded.body import resolve_name_position
 from uncoded.config import find_pyproject_toml
 
 TY_VERSION = '0.0.37'
 
-def query_references(in_path: Path, position: tuple[int, int]) -> list[Reference]:
+def find_refs(name_path: str, in_path: Path) -> list[Reference]:
+    ...
+
+def query_references(in_path: Path, position: tuple[int, int]) -> list[_LSPLocation]:
     ...
 
 def _find_root(in_path: Path) -> Path:
@@ -21,7 +25,10 @@ def _find_root(in_path: Path) -> Path:
 def _terminate(*, proc: subprocess.Popen[bytes]) -> None:
     ...
 
-def _run_exchange(*, stdin: IO[bytes], stdout: IO[bytes], in_path: Path, position: tuple[int, int], root: Path) -> list[Reference]:
+def _to_rel_path(*, path: Path) -> Path:
+    ...
+
+def _run_exchange(*, stdin: IO[bytes], stdout: IO[bytes], in_path: Path, position: tuple[int, int], root: Path) -> list[_LSPLocation]:
     ...
 
 def _write_message(*, stream: IO[bytes], msg: dict) -> None:
@@ -37,6 +44,11 @@ def _uri_to_path(uri: str) -> Path:
     ...
 
 class Reference:
+    rel_path: Path
+    line: int
+    col: int
+
+class _LSPLocation:
     path: Path
     line: int
     character: int

--- a/.uncoded/stubs/src/uncoded/resolver.pyi
+++ b/.uncoded/stubs/src/uncoded/resolver.pyi
@@ -11,7 +11,7 @@ def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
 def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
     ...
 
-def _resolve_ast_node_from_source(*, name_path: NamePath, source: str, in_path: Path) -> ast.stmt:
+def resolve_ast_node_from_source(*, name_path: NamePath, source: str, in_path: Path) -> ast.stmt:
     ...
 
 def _resolve_class_member(*, name_path: NamePath, in_path: Path, class_node: ast.ClassDef, member_name: str) -> ast.stmt:

--- a/.uncoded/stubs/src/uncoded/resolver.pyi
+++ b/.uncoded/stubs/src/uncoded/resolver.pyi
@@ -1,0 +1,34 @@
+# src/uncoded/resolver.py
+
+import ast
+from pathlib import Path
+from typing import NamedTuple
+from uncoded.ast_helpers import assign_target_name, property_kind
+
+def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
+    ...
+
+def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
+    ...
+
+def _resolve_ast_node_from_source(*, name_path: NamePath, source: str, in_path: Path) -> ast.stmt:
+    ...
+
+def _resolve_class_member(*, name_path: NamePath, in_path: Path, class_node: ast.ClassDef, member_name: str) -> ast.stmt:
+    ...
+
+class NamePath(NamedTuple):
+    head: str
+    tail: str | None = None
+
+    def parse(cls, s: str) -> 'NamePath':
+        ...
+
+    def __str__(self) -> str:
+        ...
+
+class SymbolNotFound(Exception):
+    ...
+
+class UnsupportedNamePath(Exception):
+    ...

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -2,6 +2,7 @@
 
 import ast
 import textwrap
+from unittest import mock
 import pytest
 from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_ast_node, resolve_body, resolve_name_position
 
@@ -133,6 +134,9 @@ class TestResolveNamePosition:
         ...
 
     def test_class_method(self, tmp_path):
+        ...
+
+    def test_unexpected_node_type_raises_unsupported_name_path(self, tmp_path):
         ...
 
 class TestResolveBodyByteIdentical:

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -4,7 +4,7 @@ import ast
 import textwrap
 from unittest import mock
 import pytest
-from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_ast_node, resolve_body, resolve_name_position
+from uncoded.body import SymbolNotFound, UnsupportedNamePath, resolve_ast_node, resolve_body, resolve_name_position
 
 class TestResolveBodyTopLevel:
     def test_function_without_decorators(self, tmp_path):

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -4,7 +4,7 @@ import ast
 import textwrap
 from unittest import mock
 import pytest
-from uncoded.body import SymbolNotFound, UnsupportedNamePath, resolve_ast_node, resolve_body, resolve_name_position
+from uncoded.body import NamePath, SymbolNotFound, UnsupportedNamePath, parse_name_path, resolve_ast_node, resolve_body, resolve_name_position
 
 class TestResolveBodyTopLevel:
     def test_function_without_decorators(self, tmp_path):
@@ -102,7 +102,7 @@ class TestResolveAstNode:
     def test_raises_body_not_found(self, tmp_path):
         ...
 
-    def test_raises_unsupported_name_path(self, tmp_path):
+    def test_raises_unsupported_name_path(self):
         ...
 
     def test_file_not_found_propagates(self, tmp_path):

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -1,8 +1,9 @@
 # tests/test_body.py
 
+import ast
 import textwrap
 import pytest
-from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_body
+from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_ast_node, resolve_body
 
 class TestResolveBodyTopLevel:
     def test_function_without_decorators(self, tmp_path):
@@ -88,6 +89,25 @@ class TestUnsupportedNamePath:
         ...
 
     def test_empty_middle_segment(self, tmp_path):
+        ...
+
+class TestResolveAstNode:
+    def test_returns_function_def_for_top_level_function(self, tmp_path):
+        ...
+
+    def test_returns_method_node_for_class_member(self, tmp_path):
+        ...
+
+    def test_raises_body_not_found(self, tmp_path):
+        ...
+
+    def test_raises_unsupported_name_path(self, tmp_path):
+        ...
+
+    def test_file_not_found_propagates(self, tmp_path):
+        ...
+
+    def test_syntax_error_propagates(self, tmp_path):
         ...
 
 class TestResolveBodyByteIdentical:

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -74,22 +74,22 @@ class TestResolveBodyClassMember:
 class TestUnsupportedNamePath:
     SUPPORTED_SHAPES = ("'name'", "'Class/member'")
 
-    def _assert_raises(self, name_path, tmp_path):
+    def _assert_raises(self, name_path):
         ...
 
-    def test_three_segment_path(self, tmp_path):
+    def test_three_segment_path(self):
         ...
 
-    def test_nested_class_shape(self, tmp_path):
+    def test_nested_class_shape(self):
         ...
 
-    def test_empty_leading_segment(self, tmp_path):
+    def test_empty_leading_segment(self):
         ...
 
-    def test_empty_trailing_segment(self, tmp_path):
+    def test_empty_trailing_segment(self):
         ...
 
-    def test_empty_middle_segment(self, tmp_path):
+    def test_empty_middle_segment(self):
         ...
 
 class TestResolveAstNode:

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -3,7 +3,7 @@
 import ast
 import textwrap
 import pytest
-from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_ast_node, resolve_body
+from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_ast_node, resolve_body, resolve_name_position
 
 class TestResolveBodyTopLevel:
     def test_function_without_decorators(self, tmp_path):
@@ -108,6 +108,31 @@ class TestResolveAstNode:
         ...
 
     def test_syntax_error_propagates(self, tmp_path):
+        ...
+
+class TestResolveNamePosition:
+    def test_function(self, tmp_path):
+        ...
+
+    def test_function_decorator_does_not_shift_line(self, tmp_path):
+        ...
+
+    def test_async_function(self, tmp_path):
+        ...
+
+    def test_class(self, tmp_path):
+        ...
+
+    def test_annotated_assignment(self, tmp_path):
+        ...
+
+    def test_unannotated_assignment(self, tmp_path):
+        ...
+
+    def test_type_alias(self, tmp_path):
+        ...
+
+    def test_class_method(self, tmp_path):
         ...
 
 class TestResolveBodyByteIdentical:

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -4,7 +4,8 @@ import ast
 import textwrap
 from unittest import mock
 import pytest
-from uncoded.body import NamePath, SymbolNotFound, UnsupportedNamePath, parse_name_path, resolve_ast_node, resolve_body, resolve_name_position
+from uncoded.body import resolve_body
+from uncoded.resolver import NamePath, SymbolNotFound, UnsupportedNamePath, resolve_ast_node, resolve_name_position
 
 class TestResolveBodyTopLevel:
     def test_function_without_decorators(self, tmp_path):

--- a/.uncoded/stubs/tests/test_cli.pyi
+++ b/.uncoded/stubs/tests/test_cli.pyi
@@ -3,6 +3,7 @@
 import sys
 import textwrap
 from pathlib import Path
+from unittest import mock
 import pytest
 from uncoded import cli
 from uncoded.skill import SKILL_OUTPUTS
@@ -111,4 +112,41 @@ class TestBodyCommand:
         ...
 
     def test_missing_in_flag_exits_with_two(self, tmp_path, monkeypatch, capsys):
+        ...
+
+class TestRefsCommand:
+    def test_happy_path_dispatch(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_class_method_form(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_symbol_not_found_exits_one(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_file_not_found_exits_one(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_syntax_error_exits_one(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_works_without_project_root(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_in_path_resolves_relative_to_cwd(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_unsupported_name_path_exits_one(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_missing_in_flag_exits_with_two(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_zero_references_exits_zero_with_empty_stdout(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_multiple_references_prints_sorted(self, tmp_path, monkeypatch, capsys):
+        ...
+
+    def test_lsp_failure_exits_one(self, tmp_path, monkeypatch, capsys):
         ...

--- a/.uncoded/stubs/tests/test_refs.pyi
+++ b/.uncoded/stubs/tests/test_refs.pyi
@@ -34,6 +34,9 @@ class TestFindRefs:
     def test_line_and_col_are_one_indexed(self, tmp_path):
         ...
 
+    def test_path_with_spaces_is_not_percent_encoded(self, tmp_path):
+        ...
+
 class TestToRelPath:
     def test_returns_relative_path_when_under_cwd(self, tmp_path, monkeypatch):
         ...

--- a/.uncoded/stubs/tests/test_refs.pyi
+++ b/.uncoded/stubs/tests/test_refs.pyi
@@ -7,6 +7,7 @@ import textwrap
 from pathlib import Path
 from unittest import mock
 import pytest
+from uncoded.body import NamePath
 from uncoded.refs import Reference, _find_root, _LSPLocation, _read_message, _read_response, _run_exchange, _terminate, _to_rel_path, find_refs, query_references
 
 def _lsp_stream(*msgs: dict) -> io.BytesIO:

--- a/.uncoded/stubs/tests/test_refs.pyi
+++ b/.uncoded/stubs/tests/test_refs.pyi
@@ -1,0 +1,53 @@
+# tests/test_refs.py
+
+import io
+import json
+import subprocess
+from unittest import mock
+import pytest
+from uncoded.refs import Reference, _find_root, _read_message, _read_response, _run_exchange, _terminate, query_references
+
+def _lsp_stream(*msgs: dict) -> io.BytesIO:
+    ...
+
+def _init_response() -> dict:
+    ...
+
+def _shutdown_response() -> dict:
+    ...
+
+class TestQueryReferences:
+    def test_finds_call_sites(self, tmp_path):
+        ...
+
+    def test_returns_empty_list_when_no_references(self, tmp_path):
+        ...
+
+class TestRunExchange:
+    def test_lsp_error_raises(self, tmp_path):
+        ...
+
+    def test_empty_result_list_returns_empty(self, tmp_path):
+        ...
+
+class TestFindRoot:
+    def test_returns_pyproject_parent_when_found(self, tmp_path):
+        ...
+
+    def test_returns_in_path_parent_when_not_found(self, tmp_path):
+        ...
+
+class TestTerminate:
+    def test_kills_on_timeout(self):
+        ...
+
+class TestReadMessage:
+    def test_raises_on_closed_stream(self):
+        ...
+
+    def test_parses_framed_message(self):
+        ...
+
+class TestReadResponse:
+    def test_skips_notifications_until_matching_id(self):
+        ...

--- a/.uncoded/stubs/tests/test_refs.pyi
+++ b/.uncoded/stubs/tests/test_refs.pyi
@@ -51,6 +51,9 @@ class TestQueryReferences:
     def test_uvx_not_found_raises_runtime_error(self, tmp_path):
         ...
 
+    def test_relative_path_raises_value_error(self):
+        ...
+
     def test_returns_empty_list_when_no_references(self, tmp_path):
         ...
 

--- a/.uncoded/stubs/tests/test_refs.pyi
+++ b/.uncoded/stubs/tests/test_refs.pyi
@@ -3,9 +3,11 @@
 import io
 import json
 import subprocess
+import textwrap
+from pathlib import Path
 from unittest import mock
 import pytest
-from uncoded.refs import Reference, _find_root, _read_message, _read_response, _run_exchange, _terminate, query_references
+from uncoded.refs import Reference, _find_root, _LSPLocation, _read_message, _read_response, _run_exchange, _terminate, _to_rel_path, find_refs, query_references
 
 def _lsp_stream(*msgs: dict) -> io.BytesIO:
     ...
@@ -15,6 +17,29 @@ def _init_response() -> dict:
 
 def _shutdown_response() -> dict:
     ...
+
+class TestFindRefs:
+    def test_returns_empty_for_dead_symbol(self, tmp_path):
+        ...
+
+    def test_finds_multiple_references_across_files(self, tmp_path):
+        ...
+
+    def test_class_method_shape(self, tmp_path):
+        ...
+
+    def test_results_are_sorted(self, tmp_path):
+        ...
+
+    def test_line_and_col_are_one_indexed(self, tmp_path):
+        ...
+
+class TestToRelPath:
+    def test_returns_relative_path_when_under_cwd(self, tmp_path, monkeypatch):
+        ...
+
+    def test_returns_absolute_path_when_outside_cwd(self, tmp_path, monkeypatch):
+        ...
 
 class TestQueryReferences:
     def test_finds_call_sites(self, tmp_path):

--- a/.uncoded/stubs/tests/test_refs.pyi
+++ b/.uncoded/stubs/tests/test_refs.pyi
@@ -7,8 +7,8 @@ import textwrap
 from pathlib import Path
 from unittest import mock
 import pytest
-from uncoded.body import NamePath
 from uncoded.refs import Reference, _find_root, _LSPLocation, _read_message, _read_response, _run_exchange, _terminate, _to_rel_path, find_refs, query_references
+from uncoded.resolver import NamePath
 
 def _lsp_stream(*msgs: dict) -> io.BytesIO:
     ...

--- a/.uncoded/stubs/tests/test_refs.pyi
+++ b/.uncoded/stubs/tests/test_refs.pyi
@@ -45,6 +45,9 @@ class TestQueryReferences:
     def test_finds_call_sites(self, tmp_path):
         ...
 
+    def test_uvx_not_found_raises_runtime_error(self, tmp_path):
+        ...
+
     def test_returns_empty_list_when_no_references(self, tmp_path):
         ...
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,10 @@ Two-level index:
    imports, full signatures (parameter names, types, return types),
    module constants, and class attributes.
 
-Alongside the index, uncoded also ships a one-shot setup for a language
-server, so agents can find references, rename, and safely delete symbols
-by name rather than via grep and text edits. See "How to read and edit
-code in this codebase" below for the dispatch rule.
+Alongside the index, uncoded ships `uncoded body` to read symbol bodies and
+`uncoded refs` to list all call sites, plus a one-shot language-server setup
+so agents can rename and safely delete symbols by name. See "How to read and
+edit code in this codebase" below for the dispatch rule.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,10 @@ uv run pytest tests/test_stubs.py --no-cov
 ## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
-a symbol index over its source code, with two peer tools over that index:
-`uncoded body` for reading a symbol's body, and
-[Serena](https://github.com/oraios/serena) for cross-symbol operations —
-finding references, renaming, editing by symbol, and safe-deleting.
+a symbol index over its source code, with three tools over that index:
+`uncoded body` for reading a symbol's body, `uncoded refs` for finding
+references, and [Serena](https://github.com/oraios/serena) for cross-symbol
+operations — renaming, editing by symbol, and safe-deleting.
 The point of this scaffolding is one rule.
 
 ### The dispatch rule
@@ -78,7 +78,7 @@ just the first one in the session. The pretrained reflex for "find X" is
 grep, and that reflex is wrong here. `grep -rn 'def resolve_body'` to read a
 function's body is the rule firing — that is `uncoded body`. `grep -rn
 'function_name'` to check whether something has callers before a refactor is
-the rule firing — that is `find_referencing_symbols`. `grep` then `Edit` to
+the rule firing — that is `uncoded refs`. `grep` then `Edit` to
 delete dead code is the rule firing — that is `safe_delete_symbol`. The grep
 version of any of these is noisier and less reliable: grep matches comments,
 strings, and unrelated attributes; grep misses re-exports (so caller and
@@ -118,8 +118,8 @@ source means reading many lines to learn what the stub would have told
 you in one. If no stub exists at the expected path, the file has no
 symbols indexed; in that narrow case, read source directly.
 
-**Step 3 — Act. Use `uncoded body` to read a symbol's body; use Serena to find callers,
-rename, edit, and delete symbols.**
+**Step 3 — Act. Use `uncoded body` to read a symbol's body; use `uncoded refs` to find
+callers; use Serena to rename, edit, and delete symbols.**
 With the map and stub loaded, you have the exact `relative_path` and
 `name_path` each tool needs (`ClassName/method` for a method,
 `function_name` for a top-level function). Per task:
@@ -132,12 +132,11 @@ With the map and stub loaded, you have the exact `relative_path` and
   wider sweep.
 
 - **Find callers, or check whether a symbol is dead.**
-  `find_referencing_symbols`. Returns every reference resolved by the
-  language server — every import, every call site, every re-export.
-  Grep on the name misses re-exports and adds false positives from
-  comments, strings, and attribute lookups on other types. If the
-  next move depends on the answer being complete, grep cannot give
-  you that.
+  `uncoded refs <name_path> --in <relative_path>`. Prints one reference
+  per line as `file:line:col`, sorted. Grep on the name misses re-exports
+  and adds false positives from comments, strings, and attribute lookups
+  on other types. If the next move depends on the answer being complete,
+  grep cannot give you that.
 
 - **Rename.** `rename_symbol`. Updates every reference across the
   codebase in one call. Multi-file find-and-replace misses imports
@@ -152,7 +151,7 @@ With the map and stub loaded, you have the exact `relative_path` and
   after a manual reference check. The tool fuses two operations: it
   finds every reference, refuses to delete if any are live, and
   removes the symbol cleanly only when it is truly dead. The two-step
-  version (find references with grep or `find_referencing_symbols`,
+  version (find references with grep or `uncoded refs`,
   then Edit) can drift — the reference check goes stale the moment
   any file changes between the calls. Whenever the task is "remove
   this symbol," regardless of how dead it looks, this is the tool.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ uncoded refs <name_path> --in <relative_path>
 `name_path` follows the same convention as `body`: one segment for a top-level
 symbol, two for a class member (`Class/method`). Output is one reference per
 line as `<rel_path>:<line>:<col>`, with line and column 1-indexed and results
-sorted by path then line. Exits 0 on success; empty output means no callers.
+sorted by path, then line, then column. Exits 0 on success; empty output means no callers.
 
 For example, to find all callers of `resolve_body`:
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ hallucinated understanding of code that's sitting right there, unread.
 at the start of a task and navigate deterministically to what they need —
 no guessing, no grep.
 
-It also wires up a language server so the agent can find references,
-rename, and edit symbols by name — no grep, no manual find-and-replace.
+It also ships `uncoded refs` for impact analysis and wires up a language
+server so the agent can rename, edit, and safely delete symbols by name —
+no grep, no manual find-and-replace.
 
 ## What it generates
 
@@ -74,7 +75,7 @@ uncoded setup
 
 Generates the MCP and Claude Code configuration that wires up
 [Serena][serena] (language-server bridge) and [ty][ty] (Python backend),
-so agents can find references, rename, and edit symbols by name. Safe
+so agents can rename, edit, and safely delete symbols by name. Safe
 to re-run. See [Using uncoded with a language
 server](#using-uncoded-with-a-language-server) below for the generated
 files and notes on non-Claude-Code agents.
@@ -135,6 +136,26 @@ For example, to retrieve the body of `resolve_body` from `src/uncoded/body.py`:
 uncoded body resolve_body --in src/uncoded/body.py
 ```
 
+## Find references to a symbol
+
+Use the `refs` subcommand for impact analysis: run it before a rename,
+signature change, or delete, or to confirm a symbol is dead before removing it:
+
+```
+uncoded refs <name_path> --in <relative_path>
+```
+
+`name_path` follows the same convention as `body`: one segment for a top-level
+symbol, two for a class member (`Class/method`). Output is one reference per
+line as `<rel_path>:<line>:<col>`, with line and column 1-indexed and results
+sorted by path then line. Exits 0 on success; empty output means no callers.
+
+For example, to find all callers of `resolve_body`:
+
+```
+uncoded refs resolve_body --in src/uncoded/body.py
+```
+
 ## How agents use it
 
 When `uncoded` is set up, a navigation section is automatically maintained in
@@ -144,11 +165,13 @@ Agents following that protocol:
 1. Read `.uncoded/namespace.yaml` to orient — every symbol, at a glance.
 2. Read the relevant `.pyi` stubs to understand imports, signatures, constants, and class members.
 3. Run `uncoded body <name_path> --in <relative_path>` when they need implementation detail for a specific symbol.
-4. Use [Serena](https://github.com/oraios/serena) for cross-symbol operations — finding references, renaming, editing by symbol, and safe-deleting. See [Using uncoded with a language server](#using-uncoded-with-a-language-server) for setup.
+4. Run `uncoded refs <name_path> --in <relative_path>` for impact analysis — callers, dead-symbol checks. See [Find references to a symbol](#find-references-to-a-symbol) for detail.
+5. Use [Serena](https://github.com/oraios/serena) for cross-symbol operations — renaming, editing by symbol, and safe-deleting. See [Using uncoded with a language server](#using-uncoded-with-a-language-server) for setup.
 
 The split is deliberate: `uncoded` provides a stable map and signature index;
-`uncoded body` resolves the current source body; Serena handles cross-symbol
-operations. No grep, no stale line-number coordinates, no offset arithmetic.
+`uncoded body` resolves the current source body; `uncoded refs` maps call
+sites; Serena handles rename, edit, and safe-delete. No grep, no stale
+line-number coordinates, no offset arithmetic.
 
 ## Coherence review
 
@@ -184,10 +207,10 @@ what to follow up.
 
 ## Using uncoded with a language server
 
-Symbol-level operations — finding callers, editing a single symbol,
-renaming, safe deletion — are better served by a language server
-than by grep and freeform text edits. Uncoded's map supplies the
-`name_path` and `relative_path` these tools take as input.
+Symbol-level operations — editing a single symbol, renaming, safe deletion —
+are better served by a language server than by grep and freeform text edits.
+Uncoded's map supplies the `name_path` and `relative_path` these tools take
+as input.
 
 The recommended setup is [oraios/serena][serena] as the MCP bridge with
 [astral-sh/ty][ty] as the Python language-server backend. Serena launches

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -29,12 +29,41 @@ def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
     FileNotFoundError propagate if in_path does not exist, and SyntaxError if
     in_path cannot be parsed.
     """
+    source = in_path.read_text()
+    return _resolve_ast_node_from_source(
+        name_path=name_path, source=source, in_path=in_path
+    )
+
+
+def resolve_body(name_path: str, in_path: Path) -> str:
+    """Return the source text for the symbol named by name_path in in_path.
+
+    name_path is a slash-separated path: a single segment names a top-level
+    symbol; two segments name a class member as Class/member (a method,
+    property, or attribute).
+    Raises UnsupportedNamePath if name_path has more than two segments or any
+    empty segment. Raises BodyNotFound if the symbol is not present. Lets
+    FileNotFoundError propagate if in_path does not exist, and SyntaxError if
+    in_path cannot be parsed.
+    """
+    source = in_path.read_text()
+    node = _resolve_ast_node_from_source(
+        name_path=name_path, source=source, in_path=in_path
+    )
+    return _extract_body(node=node, lines=source.splitlines(keepends=True))
+
+
+def _resolve_ast_node_from_source(
+    *,
+    name_path: str,
+    source: str,
+    in_path: Path,
+) -> ast.stmt:
     all_segments = name_path.split("/")
     if len(all_segments) > 2 or any(s == "" for s in all_segments):
         raise UnsupportedNamePath(
             f"Unsupported name_path {name_path!r}: use 'name' or 'Class/member'"
         )
-    source = in_path.read_text()
     tree = ast.parse(source, filename=str(in_path))
     head = all_segments[0]
     tail = all_segments[1] if len(all_segments) == 2 else None
@@ -69,22 +98,6 @@ def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
         )
 
     return top_match
-
-
-def resolve_body(name_path: str, in_path: Path) -> str:
-    """Return the source text for the symbol named by name_path in in_path.
-
-    name_path is a slash-separated path: a single segment names a top-level
-    symbol; two segments name a class member as Class/member (a method,
-    property, or attribute).
-    Raises UnsupportedNamePath if name_path has more than two segments or any
-    empty segment. Raises BodyNotFound if the symbol is not present. Lets
-    FileNotFoundError propagate if in_path does not exist, and SyntaxError if
-    in_path cannot be parsed.
-    """
-    node = resolve_ast_node(name_path, in_path)
-    lines = in_path.read_text().splitlines(keepends=True)
-    return _extract_body(node=node, lines=lines)
 
 
 def _resolve_class_member(

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -3,7 +3,7 @@
 import ast
 from pathlib import Path
 
-from uncoded.resolver import NamePath, _resolve_ast_node_from_source
+from uncoded.resolver import NamePath, resolve_ast_node_from_source
 
 
 def resolve_body(name_path: NamePath, in_path: Path) -> str:
@@ -14,7 +14,7 @@ def resolve_body(name_path: NamePath, in_path: Path) -> str:
     in_path cannot be parsed.
     """
     source = in_path.read_text()
-    node = _resolve_ast_node_from_source(
+    node = resolve_ast_node_from_source(
         name_path=name_path, source=source, in_path=in_path
     )
     return _extract_body(node=node, lines=source.splitlines(keepends=True))

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from uncoded.ast_helpers import assign_target_name, property_kind
 
 
-class BodyNotFound(Exception):
+class SymbolNotFound(Exception):
     """Raised when name_path cannot be found in the given file."""
 
 
@@ -25,7 +25,7 @@ def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
     symbol; two segments name a class member as Class/member (a method,
     property, or attribute).
     Raises UnsupportedNamePath if name_path has more than two segments or any
-    empty segment. Raises BodyNotFound if the symbol is not present. Lets
+    empty segment. Raises SymbolNotFound if the symbol is not present. Lets
     FileNotFoundError propagate if in_path does not exist, and SyntaxError if
     in_path cannot be parsed.
     """
@@ -41,7 +41,7 @@ def resolve_name_position(name_path: str, in_path: Path) -> tuple[int, int]:
     Follows LSP convention: both line and character are 0-indexed.
     For def/async def/class, character points past the keyword to the identifier.
     For assignments and type aliases, character points at the start of the target name.
-    Raises UnsupportedNamePath, BodyNotFound, FileNotFoundError, and SyntaxError
+    Raises UnsupportedNamePath, SymbolNotFound, FileNotFoundError, and SyntaxError
     under the same conditions as resolve_ast_node.
     """
     node = resolve_ast_node(name_path, in_path)
@@ -69,7 +69,7 @@ def resolve_body(name_path: str, in_path: Path) -> str:
     symbol; two segments name a class member as Class/member (a method,
     property, or attribute).
     Raises UnsupportedNamePath if name_path has more than two segments or any
-    empty segment. Raises BodyNotFound if the symbol is not present. Lets
+    empty segment. Raises SymbolNotFound if the symbol is not present. Lets
     FileNotFoundError propagate if in_path does not exist, and SyntaxError if
     in_path cannot be parsed.
     """
@@ -114,7 +114,7 @@ def _resolve_ast_node_from_source(
             top_match = node
 
     if top_match is None:
-        raise BodyNotFound(f"{name_path!r} not found in {in_path}")
+        raise SymbolNotFound(f"{name_path!r} not found in {in_path}")
 
     if tail is not None and isinstance(top_match, ast.ClassDef):
         return _resolve_class_member(
@@ -149,7 +149,7 @@ def _resolve_class_member(
                 match = node
 
     if match is None:
-        raise BodyNotFound(f"{name_path!r} not found in {in_path}")
+        raise SymbolNotFound(f"{name_path!r} not found in {in_path}")
 
     return match
 

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -2,8 +2,19 @@
 
 import ast
 from pathlib import Path
+from typing import NamedTuple
 
 from uncoded.ast_helpers import assign_target_name, property_kind
+
+
+class NamePath(NamedTuple):
+    """A validated name path: one segment for top-level, two for Class/member."""
+
+    head: str
+    tail: str | None = None
+
+    def __str__(self) -> str:
+        return f"{self.head}/{self.tail}" if self.tail is not None else self.head
 
 
 class SymbolNotFound(Exception):
@@ -18,14 +29,25 @@ class UnsupportedNamePath(Exception):
     """
 
 
-def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
+def parse_name_path(s: str) -> NamePath:
+    """Parse a raw name_path string into a validated NamePath.
+
+    Raises UnsupportedNamePath for more than two segments or any empty segment.
+    """
+    segments = s.split("/")
+    if len(segments) > 2 or any(seg == "" for seg in segments):
+        raise UnsupportedNamePath(
+            f"Unsupported name_path {s!r}: use 'name' or 'Class/member'"
+        )
+    head = segments[0]
+    tail = segments[1] if len(segments) == 2 else None
+    return NamePath(head=head, tail=tail)
+
+
+def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
     """Return the ast.stmt for the symbol named by name_path in in_path.
 
-    name_path is a slash-separated path: a single segment names a top-level
-    symbol; two segments name a class member as Class/member (a method,
-    property, or attribute).
-    Raises UnsupportedNamePath if name_path has more than two segments or any
-    empty segment. Raises SymbolNotFound if the symbol is not present. Lets
+    Raises SymbolNotFound if the symbol is not present. Lets
     FileNotFoundError propagate if in_path does not exist, and SyntaxError if
     in_path cannot be parsed.
     """
@@ -35,14 +57,14 @@ def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
     )
 
 
-def resolve_name_position(name_path: str, in_path: Path) -> tuple[int, int]:
+def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
     """Return the 0-indexed (line, character) position of the name token for name_path.
 
     Follows LSP convention: both line and character are 0-indexed.
     For def/async def/class, character points past the keyword to the identifier.
     For assignments and type aliases, character points at the start of the target name.
-    Raises UnsupportedNamePath, SymbolNotFound, FileNotFoundError, and SyntaxError
-    under the same conditions as resolve_ast_node.
+    Raises SymbolNotFound, FileNotFoundError, and SyntaxError under the same
+    conditions as resolve_ast_node.
     """
     node = resolve_ast_node(name_path, in_path)
     if isinstance(node, ast.FunctionDef):
@@ -57,19 +79,16 @@ def resolve_name_position(name_path: str, in_path: Path) -> tuple[int, int]:
         return (node.targets[0].lineno - 1, node.targets[0].col_offset)
     if isinstance(node, ast.TypeAlias):
         return (node.name.lineno - 1, node.name.col_offset)
+    node_type = type(node).__name__
     raise UnsupportedNamePath(
-        f"Cannot extract name position from {type(node).__name__} for {name_path!r}"
+        f"Cannot extract name position from {node_type} for {str(name_path)!r}"
     )
 
 
-def resolve_body(name_path: str, in_path: Path) -> str:
+def resolve_body(name_path: NamePath, in_path: Path) -> str:
     """Return the source text for the symbol named by name_path in in_path.
 
-    name_path is a slash-separated path: a single segment names a top-level
-    symbol; two segments name a class member as Class/member (a method,
-    property, or attribute).
-    Raises UnsupportedNamePath if name_path has more than two segments or any
-    empty segment. Raises SymbolNotFound if the symbol is not present. Lets
+    Raises SymbolNotFound if the symbol is not present. Lets
     FileNotFoundError propagate if in_path does not exist, and SyntaxError if
     in_path cannot be parsed.
     """
@@ -82,18 +101,13 @@ def resolve_body(name_path: str, in_path: Path) -> str:
 
 def _resolve_ast_node_from_source(
     *,
-    name_path: str,
+    name_path: NamePath,
     source: str,
     in_path: Path,
 ) -> ast.stmt:
-    all_segments = name_path.split("/")
-    if len(all_segments) > 2 or any(s == "" for s in all_segments):
-        raise UnsupportedNamePath(
-            f"Unsupported name_path {name_path!r}: use 'name' or 'Class/member'"
-        )
     tree = ast.parse(source, filename=str(in_path))
-    head = all_segments[0]
-    tail = all_segments[1] if len(all_segments) == 2 else None
+    head = name_path.head
+    tail = name_path.tail
 
     top_match: ast.stmt | None = None
 
@@ -114,7 +128,7 @@ def _resolve_ast_node_from_source(
             top_match = node
 
     if top_match is None:
-        raise SymbolNotFound(f"{name_path!r} not found in {in_path}")
+        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
 
     if tail is not None and isinstance(top_match, ast.ClassDef):
         return _resolve_class_member(
@@ -129,7 +143,7 @@ def _resolve_ast_node_from_source(
 
 def _resolve_class_member(
     *,
-    name_path: str,
+    name_path: NamePath,
     in_path: Path,
     class_node: ast.ClassDef,
     member_name: str,
@@ -149,7 +163,7 @@ def _resolve_class_member(
                 match = node
 
     if match is None:
-        raise SymbolNotFound(f"{name_path!r} not found in {in_path}")
+        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
 
     return match
 

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -2,7 +2,6 @@
 
 import ast
 from pathlib import Path
-from typing import cast
 
 from uncoded.ast_helpers import assign_target_name, property_kind
 
@@ -56,8 +55,11 @@ def resolve_name_position(name_path: str, in_path: Path) -> tuple[int, int]:
         return (node.target.lineno - 1, node.target.col_offset)
     if isinstance(node, ast.Assign):
         return (node.targets[0].lineno - 1, node.targets[0].col_offset)
-    alias = cast(ast.TypeAlias, node)
-    return (alias.name.lineno - 1, alias.name.col_offset)
+    if isinstance(node, ast.TypeAlias):
+        return (node.name.lineno - 1, node.name.col_offset)
+    raise UnsupportedNamePath(
+        f"Cannot extract name position from {type(node).__name__} for {name_path!r}"
+    )
 
 
 def resolve_body(name_path: str, in_path: Path) -> str:

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -1,88 +1,9 @@
-"""Resolve the source body of a named symbol in a Python file."""
+"""Retrieve the source body of a named symbol in a Python file."""
 
 import ast
 from pathlib import Path
-from typing import NamedTuple
 
-from uncoded.ast_helpers import assign_target_name, property_kind
-
-
-class NamePath(NamedTuple):
-    """A validated name path: one segment for top-level, two for Class/member."""
-
-    head: str
-    tail: str | None = None
-
-    def __str__(self) -> str:
-        return f"{self.head}/{self.tail}" if self.tail is not None else self.head
-
-
-class SymbolNotFound(Exception):
-    """Raised when name_path cannot be found in the given file."""
-
-
-class UnsupportedNamePath(Exception):
-    """Raised when name_path does not match a supported shape.
-
-    Supported shapes are 'name' (one segment) or 'Class/member' (two segments),
-    both non-empty.
-    """
-
-
-def parse_name_path(s: str) -> NamePath:
-    """Parse a raw name_path string into a validated NamePath.
-
-    Raises UnsupportedNamePath for more than two segments or any empty segment.
-    """
-    segments = s.split("/")
-    if len(segments) > 2 or any(seg == "" for seg in segments):
-        raise UnsupportedNamePath(
-            f"Unsupported name_path {s!r}: use 'name' or 'Class/member'"
-        )
-    head = segments[0]
-    tail = segments[1] if len(segments) == 2 else None
-    return NamePath(head=head, tail=tail)
-
-
-def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
-    """Return the ast.stmt for the symbol named by name_path in in_path.
-
-    Raises SymbolNotFound if the symbol is not present. Lets
-    FileNotFoundError propagate if in_path does not exist, and SyntaxError if
-    in_path cannot be parsed.
-    """
-    source = in_path.read_text()
-    return _resolve_ast_node_from_source(
-        name_path=name_path, source=source, in_path=in_path
-    )
-
-
-def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
-    """Return the 0-indexed (line, character) position of the name token for name_path.
-
-    Follows LSP convention: both line and character are 0-indexed.
-    For def/async def/class, character points past the keyword to the identifier.
-    For assignments and type aliases, character points at the start of the target name.
-    Raises SymbolNotFound, FileNotFoundError, and SyntaxError under the same
-    conditions as resolve_ast_node.
-    """
-    node = resolve_ast_node(name_path, in_path)
-    if isinstance(node, ast.FunctionDef):
-        return (node.lineno - 1, node.col_offset + len("def "))
-    if isinstance(node, ast.AsyncFunctionDef):
-        return (node.lineno - 1, node.col_offset + len("async def "))
-    if isinstance(node, ast.ClassDef):
-        return (node.lineno - 1, node.col_offset + len("class "))
-    if isinstance(node, ast.AnnAssign):
-        return (node.target.lineno - 1, node.target.col_offset)
-    if isinstance(node, ast.Assign):
-        return (node.targets[0].lineno - 1, node.targets[0].col_offset)
-    if isinstance(node, ast.TypeAlias):
-        return (node.name.lineno - 1, node.name.col_offset)
-    node_type = type(node).__name__
-    raise UnsupportedNamePath(
-        f"Cannot extract name position from {node_type} for {str(name_path)!r}"
-    )
+from uncoded.resolver import NamePath, _resolve_ast_node_from_source
 
 
 def resolve_body(name_path: NamePath, in_path: Path) -> str:
@@ -97,75 +18,6 @@ def resolve_body(name_path: NamePath, in_path: Path) -> str:
         name_path=name_path, source=source, in_path=in_path
     )
     return _extract_body(node=node, lines=source.splitlines(keepends=True))
-
-
-def _resolve_ast_node_from_source(
-    *,
-    name_path: NamePath,
-    source: str,
-    in_path: Path,
-) -> ast.stmt:
-    tree = ast.parse(source, filename=str(in_path))
-    head = name_path.head
-    tail = name_path.tail
-
-    top_match: ast.stmt | None = None
-
-    for node in ast.iter_child_nodes(tree):
-        matches_class = isinstance(node, ast.ClassDef) and node.name == head
-        matches_function = (
-            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and tail is None
-            and node.name == head
-        )
-        if matches_class or matches_function:
-            top_match = node
-        elif isinstance(node, (ast.Assign, ast.AnnAssign)) and tail is None:
-            name = assign_target_name(node)
-            if name == head:
-                top_match = node
-        elif isinstance(node, ast.TypeAlias) and tail is None and node.name.id == head:
-            top_match = node
-
-    if top_match is None:
-        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
-
-    if tail is not None and isinstance(top_match, ast.ClassDef):
-        return _resolve_class_member(
-            name_path=name_path,
-            in_path=in_path,
-            class_node=top_match,
-            member_name=tail,
-        )
-
-    return top_match
-
-
-def _resolve_class_member(
-    *,
-    name_path: NamePath,
-    in_path: Path,
-    class_node: ast.ClassDef,
-    member_name: str,
-) -> ast.stmt:
-    match: ast.stmt | None = None
-
-    for node in ast.iter_child_nodes(class_node):
-        if isinstance(node, (ast.Assign, ast.AnnAssign)):
-            name = assign_target_name(node)
-            if name == member_name:
-                match = node
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            kind = property_kind(node)
-            if kind in ("setter", "deleter"):
-                continue
-            if node.name == member_name:
-                match = node
-
-    if match is None:
-        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
-
-    return match
 
 
 def _extract_body(*, node: ast.stmt, lines: list[str]) -> str:

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -2,6 +2,7 @@
 
 import ast
 from pathlib import Path
+from typing import cast
 
 from uncoded.ast_helpers import assign_target_name, property_kind
 
@@ -33,6 +34,30 @@ def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
     return _resolve_ast_node_from_source(
         name_path=name_path, source=source, in_path=in_path
     )
+
+
+def resolve_name_position(name_path: str, in_path: Path) -> tuple[int, int]:
+    """Return the 0-indexed (line, character) position of the name token for name_path.
+
+    Follows LSP convention: both line and character are 0-indexed.
+    For def/async def/class, character points past the keyword to the identifier.
+    For assignments and type aliases, character points at the start of the target name.
+    Raises UnsupportedNamePath, BodyNotFound, FileNotFoundError, and SyntaxError
+    under the same conditions as resolve_ast_node.
+    """
+    node = resolve_ast_node(name_path, in_path)
+    if isinstance(node, ast.FunctionDef):
+        return (node.lineno - 1, node.col_offset + len("def "))
+    if isinstance(node, ast.AsyncFunctionDef):
+        return (node.lineno - 1, node.col_offset + len("async def "))
+    if isinstance(node, ast.ClassDef):
+        return (node.lineno - 1, node.col_offset + len("class "))
+    if isinstance(node, ast.AnnAssign):
+        return (node.target.lineno - 1, node.target.col_offset)
+    if isinstance(node, ast.Assign):
+        return (node.targets[0].lineno - 1, node.targets[0].col_offset)
+    alias = cast(ast.TypeAlias, node)
+    return (alias.name.lineno - 1, alias.name.col_offset)
 
 
 def resolve_body(name_path: str, in_path: Path) -> str:

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -18,8 +18,8 @@ class UnsupportedNamePath(Exception):
     """
 
 
-def resolve_body(name_path: str, in_path: Path) -> str:
-    """Return the source text for the symbol named by name_path in in_path.
+def resolve_ast_node(name_path: str, in_path: Path) -> ast.stmt:
+    """Return the ast.stmt for the symbol named by name_path in in_path.
 
     name_path is a slash-separated path: a single segment names a top-level
     symbol; two segments name a class member as Class/member (a method,
@@ -36,11 +36,10 @@ def resolve_body(name_path: str, in_path: Path) -> str:
         )
     source = in_path.read_text()
     tree = ast.parse(source, filename=str(in_path))
-    lines = source.splitlines(keepends=True)
     head = all_segments[0]
     tail = all_segments[1] if len(all_segments) == 2 else None
 
-    match: ast.stmt | None = None
+    top_match: ast.stmt | None = None
 
     for node in ast.iter_child_nodes(tree):
         matches_class = isinstance(node, ast.ClassDef) and node.name == head
@@ -50,27 +49,42 @@ def resolve_body(name_path: str, in_path: Path) -> str:
             and node.name == head
         )
         if matches_class or matches_function:
-            match = node
+            top_match = node
         elif isinstance(node, (ast.Assign, ast.AnnAssign)) and tail is None:
             name = assign_target_name(node)
             if name == head:
-                match = node
+                top_match = node
         elif isinstance(node, ast.TypeAlias) and tail is None and node.name.id == head:
-            match = node
+            top_match = node
 
-    if match is None:
+    if top_match is None:
         raise BodyNotFound(f"{name_path!r} not found in {in_path}")
 
-    if tail is not None and isinstance(match, ast.ClassDef):
+    if tail is not None and isinstance(top_match, ast.ClassDef):
         return _resolve_class_member(
             name_path=name_path,
             in_path=in_path,
-            class_node=match,
+            class_node=top_match,
             member_name=tail,
-            lines=lines,
         )
 
-    return _extract_body(node=match, lines=lines)
+    return top_match
+
+
+def resolve_body(name_path: str, in_path: Path) -> str:
+    """Return the source text for the symbol named by name_path in in_path.
+
+    name_path is a slash-separated path: a single segment names a top-level
+    symbol; two segments name a class member as Class/member (a method,
+    property, or attribute).
+    Raises UnsupportedNamePath if name_path has more than two segments or any
+    empty segment. Raises BodyNotFound if the symbol is not present. Lets
+    FileNotFoundError propagate if in_path does not exist, and SyntaxError if
+    in_path cannot be parsed.
+    """
+    node = resolve_ast_node(name_path, in_path)
+    lines = in_path.read_text().splitlines(keepends=True)
+    return _extract_body(node=node, lines=lines)
 
 
 def _resolve_class_member(
@@ -79,8 +93,7 @@ def _resolve_class_member(
     in_path: Path,
     class_node: ast.ClassDef,
     member_name: str,
-    lines: list[str],
-) -> str:
+) -> ast.stmt:
     match: ast.stmt | None = None
 
     for node in ast.iter_child_nodes(class_node):
@@ -98,7 +111,7 @@ def _resolve_class_member(
     if match is None:
         raise BodyNotFound(f"{name_path!r} not found in {in_path}")
 
-    return _extract_body(node=match, lines=lines)
+    return match
 
 
 def _extract_body(*, node: ast.stmt, lines: list[str]) -> str:

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -4,7 +4,12 @@ import argparse
 import sys
 from pathlib import Path
 
-from uncoded.body import SymbolNotFound, UnsupportedNamePath, resolve_body
+from uncoded.body import (
+    SymbolNotFound,
+    UnsupportedNamePath,
+    parse_name_path,
+    resolve_body,
+)
 from uncoded.config import (
     find_pyproject_toml,
     read_instruction_files,
@@ -147,7 +152,7 @@ def _body(*, name_path: str, in_path: str) -> int:
     """
     target = Path(in_path)
     try:
-        body = resolve_body(name_path, target)
+        body = resolve_body(parse_name_path(name_path), target)
     except UnsupportedNamePath as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -175,7 +180,7 @@ def _refs(*, name_path: str, in_path: str) -> int:
     # raises ValueError on a relative path.
     target = Path(in_path).resolve()
     try:
-        refs = find_refs(name_path, target)
+        refs = find_refs(parse_name_path(name_path), target)
     except UnsupportedNamePath as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -13,6 +13,7 @@ from uncoded.config import (
 from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
+from uncoded.refs import find_refs
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
 from uncoded.stubs import build_stubs
@@ -164,10 +165,40 @@ def _body(*, name_path: str, in_path: str) -> int:
     return 0
 
 
+def _refs(*, name_path: str, in_path: str) -> int:
+    """Find all references to name_path in in_path and print them to stdout.
+
+    Returns 0 on success. Each reference is printed as rel_path:line:col.
+    Returns 1 on any error.
+    """
+    target = Path(in_path).resolve()
+    try:
+        refs = find_refs(name_path, target)
+    except UnsupportedNamePath as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except BodyNotFound:
+        print(f"Error: {name_path!r} not found in {in_path}", file=sys.stderr)
+        return 1
+    except FileNotFoundError:
+        print(f"Error: {in_path}: file not found.", file=sys.stderr)
+        return 1
+    except SyntaxError as e:
+        print(f"Error: {in_path}: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    for ref in refs:
+        print(f"{ref.rel_path}:{ref.line}:{ref.col}")
+    return 0
+
+
 def main() -> int:
     """Dispatch the uncoded CLI.
 
-    Four subcommands:
+    Five subcommands:
 
     - ``sync`` — builds or refreshes the navigation index.
     - ``check`` — verifies the index matches what a rebuild would produce;
@@ -175,6 +206,7 @@ def main() -> int:
     - ``setup`` — generates MCP and Claude Code config for the recommended
       Serena + ty LSP integration.
     - ``body`` — prints the source body of a named symbol to stdout.
+    - ``refs`` — finds all references to a named symbol and prints them.
 
     Each subparser binds its own ``action`` callable via
     ``set_defaults``; ``main`` then dispatches via ``args.action()``.
@@ -232,6 +264,25 @@ def main() -> int:
     )
     body_parser.set_defaults(
         action=lambda: _body(name_path=args.name_path, in_path=args.in_path)
+    )
+
+    refs_parser = subparsers.add_parser(
+        "refs",
+        help="Find all references to a named symbol and print them to stdout.",
+    )
+    refs_parser.add_argument(
+        "name_path",
+        help="Symbol path: one segment for top-level, two for Class/member.",
+    )
+    refs_parser.add_argument(
+        "--in",
+        dest="in_path",
+        required=True,
+        metavar="PATH",
+        help="Source file path (relative to current directory).",
+    )
+    refs_parser.set_defaults(
+        action=lambda: _refs(name_path=args.name_path, in_path=args.in_path)
     )
 
     args = parser.parse_args()

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_body
+from uncoded.body import SymbolNotFound, UnsupportedNamePath, resolve_body
 from uncoded.config import (
     find_pyproject_toml,
     read_instruction_files,
@@ -151,7 +151,7 @@ def _body(*, name_path: str, in_path: str) -> int:
     except UnsupportedNamePath as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    except BodyNotFound:
+    except SymbolNotFound:
         print(f"Error: {name_path!r} not found in {in_path}", file=sys.stderr)
         return 1
     except FileNotFoundError:
@@ -179,7 +179,7 @@ def _refs(*, name_path: str, in_path: str) -> int:
     except UnsupportedNamePath as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    except BodyNotFound:
+    except SymbolNotFound:
         print(f"Error: {name_path!r} not found in {in_path}", file=sys.stderr)
         return 1
     except FileNotFoundError:

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -186,7 +186,7 @@ def _refs(*, name_path: str, in_path: str) -> int:
     except SyntaxError as e:
         print(f"Error: {in_path}: {e}", file=sys.stderr)
         return 1
-    except Exception as e:
+    except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -4,12 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from uncoded.body import (
-    SymbolNotFound,
-    UnsupportedNamePath,
-    parse_name_path,
-    resolve_body,
-)
+from uncoded.body import resolve_body
 from uncoded.config import (
     find_pyproject_toml,
     read_instruction_files,
@@ -19,6 +14,7 @@ from uncoded.extract import extract_modules, iter_source_files
 from uncoded.instruction_files import sync_instruction_file
 from uncoded.namespace_map import build_map, render_map
 from uncoded.refs import find_refs
+from uncoded.resolver import NamePath, SymbolNotFound, UnsupportedNamePath
 from uncoded.serena_setup import setup
 from uncoded.skill import sync_skill
 from uncoded.stubs import build_stubs
@@ -152,7 +148,7 @@ def _body(*, name_path: str, in_path: str) -> int:
     """
     target = Path(in_path)
     try:
-        body = resolve_body(parse_name_path(name_path), target)
+        body = resolve_body(NamePath.parse(name_path), target)
     except UnsupportedNamePath as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -180,7 +176,7 @@ def _refs(*, name_path: str, in_path: str) -> int:
     # raises ValueError on a relative path.
     target = Path(in_path).resolve()
     try:
-        refs = find_refs(parse_name_path(name_path), target)
+        refs = find_refs(NamePath.parse(name_path), target)
     except UnsupportedNamePath as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -171,6 +171,8 @@ def _refs(*, name_path: str, in_path: str) -> int:
     Returns 0 on success. Each reference is printed as rel_path:line:col.
     Returns 1 on any error.
     """
+    # resolve() is required: query_references calls Path.as_uri(), which
+    # raises ValueError on a relative path.
     target = Path(in_path).resolve()
     try:
         refs = find_refs(name_path, target)

--- a/src/uncoded/instruction_files.py
+++ b/src/uncoded/instruction_files.py
@@ -22,10 +22,10 @@ _SECTION_BODY = """\
 ## How to read and edit code in this codebase
 
 This repo uses [uncoded](https://github.com/alimanfoo/uncoded) to maintain
-a symbol index over its source code, with two peer tools over that index:
-`uncoded body` for reading a symbol's body, and
-[Serena](https://github.com/oraios/serena) for cross-symbol operations —
-finding references, renaming, editing by symbol, and safe-deleting.
+a symbol index over its source code, with three tools over that index:
+`uncoded body` for reading a symbol's body, `uncoded refs` for finding
+references, and [Serena](https://github.com/oraios/serena) for cross-symbol
+operations — renaming, editing by symbol, and safe-deleting.
 The point of this scaffolding is one rule.
 
 ### The dispatch rule
@@ -39,7 +39,7 @@ just the first one in the session. The pretrained reflex for "find X" is
 grep, and that reflex is wrong here. `grep -rn 'def resolve_body'` to read a
 function's body is the rule firing — that is `uncoded body`. `grep -rn
 'function_name'` to check whether something has callers before a refactor is
-the rule firing — that is `find_referencing_symbols`. `grep` then `Edit` to
+the rule firing — that is `uncoded refs`. `grep` then `Edit` to
 delete dead code is the rule firing — that is `safe_delete_symbol`. The grep
 version of any of these is noisier and less reliable: grep matches comments,
 strings, and unrelated attributes; grep misses re-exports (so caller and
@@ -79,8 +79,8 @@ source means reading many lines to learn what the stub would have told
 you in one. If no stub exists at the expected path, the file has no
 symbols indexed; in that narrow case, read source directly.
 
-**Step 3 — Act. Use `uncoded body` to read a symbol's body; use Serena to find callers,
-rename, edit, and delete symbols.**
+**Step 3 — Act. Use `uncoded body` to read a symbol's body; use `uncoded refs` to find
+callers; use Serena to rename, edit, and delete symbols.**
 With the map and stub loaded, you have the exact `relative_path` and
 `name_path` each tool needs (`ClassName/method` for a method,
 `function_name` for a top-level function). Per task:
@@ -93,12 +93,11 @@ With the map and stub loaded, you have the exact `relative_path` and
   wider sweep.
 
 - **Find callers, or check whether a symbol is dead.**
-  `find_referencing_symbols`. Returns every reference resolved by the
-  language server — every import, every call site, every re-export.
-  Grep on the name misses re-exports and adds false positives from
-  comments, strings, and attribute lookups on other types. If the
-  next move depends on the answer being complete, grep cannot give
-  you that.
+  `uncoded refs <name_path> --in <relative_path>`. Prints one reference
+  per line as `file:line:col`, sorted. Grep on the name misses re-exports
+  and adds false positives from comments, strings, and attribute lookups
+  on other types. If the next move depends on the answer being complete,
+  grep cannot give you that.
 
 - **Rename.** `rename_symbol`. Updates every reference across the
   codebase in one call. Multi-file find-and-replace misses imports
@@ -113,7 +112,7 @@ With the map and stub loaded, you have the exact `relative_path` and
   after a manual reference check. The tool fuses two operations: it
   finds every reference, refuses to delete if any are live, and
   removes the symbol cleanly only when it is truly dead. The two-step
-  version (find references with grep or `find_referencing_symbols`,
+  version (find references with grep or `uncoded refs`,
   then Edit) can drift — the reference check goes stale the moment
   any file changes between the calls. Whenever the task is "remove
   this symbol," regardless of how dead it looks, this is the tool.

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -1,0 +1,178 @@
+"""Minimal LSP client that queries ty for textDocument/references."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, cast
+from urllib.parse import urlparse
+
+from uncoded.config import find_pyproject_toml
+
+TY_VERSION = "0.0.37"
+
+
+@dataclass(frozen=True)
+class Reference:
+    """A single reference location returned by ty's LSP server."""
+
+    path: Path
+    line: int
+    character: int
+
+
+def query_references(in_path: Path, position: tuple[int, int]) -> list[Reference]:
+    """Return all references to the symbol at position in in_path.
+
+    Spawns ty as a one-shot LSP subprocess and performs the full
+    initialize/didOpen/references/shutdown exchange.
+    position follows LSP convention: (line, character), both 0-indexed.
+    """
+    root = _find_root(in_path)
+    proc = subprocess.Popen(
+        ["uvx", "--from", f"ty=={TY_VERSION}", "ty", "server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        return _run_exchange(
+            stdin=cast(IO[bytes], proc.stdin),
+            stdout=cast(IO[bytes], proc.stdout),
+            in_path=in_path,
+            position=position,
+            root=root,
+        )
+    finally:
+        _terminate(proc=proc)
+
+
+def _find_root(in_path: Path) -> Path:
+    pyproject = find_pyproject_toml(in_path.parent)
+    return pyproject.parent if pyproject is not None else in_path.parent
+
+
+def _terminate(*, proc: subprocess.Popen[bytes]) -> None:
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        proc.wait()
+
+
+def _run_exchange(
+    *,
+    stdin: IO[bytes],
+    stdout: IO[bytes],
+    in_path: Path,
+    position: tuple[int, int],
+    root: Path,
+) -> list[Reference]:
+    root_uri = root.as_uri()
+    file_uri = in_path.as_uri()
+
+    _write_message(
+        stream=stdin,
+        msg={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "processId": os.getpid(),
+                "rootUri": root_uri,
+                "workspaceFolders": [{"uri": root_uri, "name": root.name}],
+                "capabilities": {},
+            },
+        },
+    )
+    _read_response(stream=stdout, request_id=1)
+
+    _write_message(
+        stream=stdin,
+        msg={"jsonrpc": "2.0", "method": "initialized", "params": {}},
+    )
+
+    _write_message(
+        stream=stdin,
+        msg={
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": file_uri,
+                    "languageId": "python",
+                    "version": 1,
+                    "text": in_path.read_text(),
+                }
+            },
+        },
+    )
+
+    line, character = position
+    _write_message(
+        stream=stdin,
+        msg={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/references",
+            "params": {
+                "textDocument": {"uri": file_uri},
+                "position": {"line": line, "character": character},
+                "context": {"includeDeclaration": False},
+            },
+        },
+    )
+    response = _read_response(stream=stdout, request_id=2)
+
+    if "error" in response:
+        raise RuntimeError(f"ty LSP error: {response['error']}")
+
+    _write_message(
+        stream=stdin,
+        msg={"jsonrpc": "2.0", "id": 3, "method": "shutdown", "params": None},
+    )
+    _read_response(stream=stdout, request_id=3)
+    _write_message(stream=stdin, msg={"jsonrpc": "2.0", "method": "exit"})
+
+    result = response["result"]
+    if result is None:
+        return []
+    return [
+        Reference(
+            path=_uri_to_path(loc["uri"]),
+            line=loc["range"]["start"]["line"],
+            character=loc["range"]["start"]["character"],
+        )
+        for loc in result
+    ]
+
+
+def _write_message(*, stream: IO[bytes], msg: dict) -> None:
+    data = json.dumps(msg).encode("utf-8")
+    stream.write(f"Content-Length: {len(data)}\r\n\r\n".encode("ascii") + data)
+    stream.flush()
+
+
+def _read_message(*, stream: IO[bytes]) -> dict:
+    headers = b""
+    while not headers.endswith(b"\r\n\r\n"):
+        ch = stream.read(1)
+        if not ch:
+            raise RuntimeError("ty closed stdout unexpectedly")
+        headers += ch
+    length = int(headers.split(b"\r\n")[0].split(b":", 1)[1].strip())
+    return json.loads(stream.read(length).decode("utf-8"))
+
+
+def _read_response(*, stream: IO[bytes], request_id: int) -> dict:
+    while True:
+        msg = _read_message(stream=stream)
+        if msg.get("id") == request_id:
+            return msg
+
+
+def _uri_to_path(uri: str) -> Path:
+    return Path(urlparse(uri).path)

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -52,6 +52,8 @@ def find_refs(name_path: str, in_path: Path) -> list[Reference]:
 def query_references(in_path: Path, position: tuple[int, int]) -> list[_LSPLocation]:
     """Return raw LSP reference locations for the symbol at position in in_path.
 
+    in_path must be an absolute path; a relative path raises ValueError when
+    converted to a file URI internally.
     Spawns ty as a one-shot LSP subprocess and performs the full
     initialize/didOpen/references/shutdown exchange.
     position follows LSP convention: (line, character), both 0-indexed.

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -8,7 +8,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, cast
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from uncoded.body import resolve_name_position
 from uncoded.config import find_pyproject_toml
@@ -222,4 +222,4 @@ def _read_response(*, stream: IO[bytes], request_id: int) -> dict:
 
 
 def _uri_to_path(uri: str) -> Path:
-    return Path(urlparse(uri).path)
+    return Path(unquote(urlparse(uri).path))

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -32,7 +32,7 @@ def find_refs(name_path: str, in_path: Path) -> list[Reference]:
     references, and returns results with 1-indexed line/col sorted by
     (rel_path, line, col). rel_path is relative to the current working
     directory when possible; otherwise absolute.
-    Propagates UnsupportedNamePath, BodyNotFound, FileNotFoundError, and
+    Propagates UnsupportedNamePath, SymbolNotFound, FileNotFoundError, and
     SyntaxError from resolve_name_position.
     """
     position = resolve_name_position(name_path, in_path)

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import IO, cast
 from urllib.parse import unquote, urlparse
 
-from uncoded.body import resolve_name_position
+from uncoded.body import NamePath, resolve_name_position
 from uncoded.config import find_pyproject_toml
 
 TY_VERSION = "0.0.37"
@@ -25,15 +25,15 @@ class Reference:
     col: int
 
 
-def find_refs(name_path: str, in_path: Path) -> list[Reference]:
+def find_refs(name_path: NamePath, in_path: Path) -> list[Reference]:
     """Return all references to the symbol named by name_path in in_path.
 
     Resolves the symbol's name-token position, queries ty's LSP server for
     references, and returns results with 1-indexed line/col sorted by
     (rel_path, line, col). rel_path is relative to the current working
     directory when possible; otherwise absolute.
-    Propagates UnsupportedNamePath, SymbolNotFound, FileNotFoundError, and
-    SyntaxError from resolve_name_position.
+    Propagates SymbolNotFound, FileNotFoundError, and SyntaxError from
+    resolve_name_position.
     """
     position = resolve_name_position(name_path, in_path)
     raw_refs = query_references(in_path, position)

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -57,12 +57,17 @@ def query_references(in_path: Path, position: tuple[int, int]) -> list[_LSPLocat
     position follows LSP convention: (line, character), both 0-indexed.
     """
     root = _find_root(in_path)
-    proc = subprocess.Popen(
-        ["uvx", "--from", f"ty=={TY_VERSION}", "ty", "server"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    try:
+        proc = subprocess.Popen(
+            ["uvx", "--from", f"ty=={TY_VERSION}", "ty", "server"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "uvx not found on PATH — install uv (https://docs.astral.sh/uv/)"
+        ) from exc
     try:
         return _run_exchange(
             stdin=cast(IO[bytes], proc.stdin),
@@ -169,7 +174,8 @@ def _run_exchange(
     response = _read_response(stream=stdout, request_id=2)
 
     if "error" in response:
-        raise RuntimeError(f"ty LSP error: {response['error']}")
+        error = response["error"]
+        raise RuntimeError(f"ty LSP error: {error.get('message', error)}")
 
     _write_message(
         stream=stdin,

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import IO, cast
 from urllib.parse import unquote, urlparse
 
-from uncoded.body import NamePath, resolve_name_position
 from uncoded.config import find_pyproject_toml
+from uncoded.resolver import NamePath, resolve_name_position
 
 TY_VERSION = "0.0.37"
 

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -62,7 +62,7 @@ def query_references(in_path: Path, position: tuple[int, int]) -> list[_LSPLocat
             ["uvx", "--from", f"ty=={TY_VERSION}", "ty", "server"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
         )
     except FileNotFoundError as exc:
         raise RuntimeError(
@@ -173,16 +173,16 @@ def _run_exchange(
     )
     response = _read_response(stream=stdout, request_id=2)
 
-    if "error" in response:
-        error = response["error"]
-        raise RuntimeError(f"ty LSP error: {error.get('message', error)}")
-
     _write_message(
         stream=stdin,
         msg={"jsonrpc": "2.0", "id": 3, "method": "shutdown", "params": None},
     )
     _read_response(stream=stdout, request_id=3)
     _write_message(stream=stdin, msg={"jsonrpc": "2.0", "method": "exit"})
+
+    if "error" in response:
+        error = response["error"]
+        raise RuntimeError(f"ty LSP error: {error.get('message', error)}")
 
     result = response["result"]
     if result is None:

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import IO, cast
 from urllib.parse import urlparse
 
+from uncoded.body import resolve_name_position
 from uncoded.config import find_pyproject_toml
 
 TY_VERSION = "0.0.37"
@@ -17,15 +18,39 @@ TY_VERSION = "0.0.37"
 
 @dataclass(frozen=True)
 class Reference:
-    """A single reference location returned by ty's LSP server."""
+    """A reference location with 1-indexed line and column."""
 
-    path: Path
+    rel_path: Path
     line: int
-    character: int
+    col: int
 
 
-def query_references(in_path: Path, position: tuple[int, int]) -> list[Reference]:
-    """Return all references to the symbol at position in in_path.
+def find_refs(name_path: str, in_path: Path) -> list[Reference]:
+    """Return all references to the symbol named by name_path in in_path.
+
+    Resolves the symbol's name-token position, queries ty's LSP server for
+    references, and returns results with 1-indexed line/col sorted by
+    (rel_path, line, col). rel_path is relative to the current working
+    directory when possible; otherwise absolute.
+    Propagates UnsupportedNamePath, BodyNotFound, FileNotFoundError, and
+    SyntaxError from resolve_name_position.
+    """
+    position = resolve_name_position(name_path, in_path)
+    raw_refs = query_references(in_path, position)
+    result = [
+        Reference(
+            rel_path=_to_rel_path(path=ref.path),
+            line=ref.line + 1,
+            col=ref.character + 1,
+        )
+        for ref in raw_refs
+    ]
+    result.sort(key=lambda r: (r.rel_path, r.line, r.col))
+    return result
+
+
+def query_references(in_path: Path, position: tuple[int, int]) -> list[_LSPLocation]:
+    """Return raw LSP reference locations for the symbol at position in in_path.
 
     Spawns ty as a one-shot LSP subprocess and performs the full
     initialize/didOpen/references/shutdown exchange.
@@ -50,6 +75,15 @@ def query_references(in_path: Path, position: tuple[int, int]) -> list[Reference
         _terminate(proc=proc)
 
 
+@dataclass(frozen=True)
+class _LSPLocation:
+    """Raw LSP reference location with 0-indexed line and character."""
+
+    path: Path
+    line: int
+    character: int
+
+
 def _find_root(in_path: Path) -> Path:
     pyproject = find_pyproject_toml(in_path.parent)
     return pyproject.parent if pyproject is not None else in_path.parent
@@ -63,6 +97,13 @@ def _terminate(*, proc: subprocess.Popen[bytes]) -> None:
         proc.wait()
 
 
+def _to_rel_path(*, path: Path) -> Path:
+    try:
+        return path.relative_to(Path.cwd())
+    except ValueError:
+        return path
+
+
 def _run_exchange(
     *,
     stdin: IO[bytes],
@@ -70,7 +111,7 @@ def _run_exchange(
     in_path: Path,
     position: tuple[int, int],
     root: Path,
-) -> list[Reference]:
+) -> list[_LSPLocation]:
     root_uri = root.as_uri()
     file_uri = in_path.as_uri()
 
@@ -141,7 +182,7 @@ def _run_exchange(
     if result is None:
         return []
     return [
-        Reference(
+        _LSPLocation(
             path=_uri_to_path(loc["uri"]),
             line=loc["range"]["start"]["line"],
             character=loc["range"]["start"]["character"],

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -52,12 +52,13 @@ def find_refs(name_path: str, in_path: Path) -> list[Reference]:
 def query_references(in_path: Path, position: tuple[int, int]) -> list[_LSPLocation]:
     """Return raw LSP reference locations for the symbol at position in in_path.
 
-    in_path must be an absolute path; a relative path raises ValueError when
-    converted to a file URI internally.
+    in_path must be an absolute path; a relative path raises ValueError.
     Spawns ty as a one-shot LSP subprocess and performs the full
     initialize/didOpen/references/shutdown exchange.
     position follows LSP convention: (line, character), both 0-indexed.
     """
+    if not in_path.is_absolute():
+        raise ValueError(f"query_references requires an absolute path; got {in_path!r}")
     root = _find_root(in_path)
     try:
         proc = subprocess.Popen(

--- a/src/uncoded/resolver.py
+++ b/src/uncoded/resolver.py
@@ -52,7 +52,7 @@ def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
     in_path cannot be parsed.
     """
     source = in_path.read_text()
-    return _resolve_ast_node_from_source(
+    return resolve_ast_node_from_source(
         name_path=name_path, source=source, in_path=in_path
     )
 
@@ -85,12 +85,21 @@ def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]
     )
 
 
-def _resolve_ast_node_from_source(
+def resolve_ast_node_from_source(
     *,
     name_path: NamePath,
     source: str,
     in_path: Path,
 ) -> ast.stmt:
+    """Return the ast.stmt for name_path given an already-read source string.
+
+    The primitive that lets resolve_ast_node and resolve_body share a single
+    file read. Callers that already have the source string call this directly
+    to avoid reading in_path again. in_path is used only for ast.parse's
+    filename argument and for error messages.
+    Raises SymbolNotFound if the symbol is not present; propagates SyntaxError
+    if source cannot be parsed.
+    """
     tree = ast.parse(source, filename=str(in_path))
     head = name_path.head
     tail = name_path.tail

--- a/src/uncoded/resolver.py
+++ b/src/uncoded/resolver.py
@@ -1,0 +1,154 @@
+"""Name-path resolution: parse, AST-walk, and position extraction."""
+
+import ast
+from pathlib import Path
+from typing import NamedTuple
+
+from uncoded.ast_helpers import assign_target_name, property_kind
+
+
+class NamePath(NamedTuple):
+    """A validated name path: one segment for top-level, two for Class/member."""
+
+    head: str
+    tail: str | None = None
+
+    @classmethod
+    def parse(cls, s: str) -> "NamePath":
+        """Parse a raw name_path string into a validated NamePath.
+
+        Raises UnsupportedNamePath for more than two segments or any empty segment.
+        """
+        segments = s.split("/")
+        if len(segments) > 2 or any(seg == "" for seg in segments):
+            raise UnsupportedNamePath(
+                f"Unsupported name_path {s!r}: use 'name' or 'Class/member'"
+            )
+        head = segments[0]
+        tail = segments[1] if len(segments) == 2 else None
+        return cls(head=head, tail=tail)
+
+    def __str__(self) -> str:
+        return f"{self.head}/{self.tail}" if self.tail is not None else self.head
+
+
+class SymbolNotFound(Exception):
+    """Raised when name_path cannot be found in the given file."""
+
+
+class UnsupportedNamePath(Exception):
+    """Raised when name_path does not match a supported shape.
+
+    Supported shapes are 'name' (one segment) or 'Class/member' (two segments),
+    both non-empty.
+    """
+
+
+def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
+    """Return the ast.stmt for the symbol named by name_path in in_path.
+
+    Raises SymbolNotFound if the symbol is not present. Lets
+    FileNotFoundError propagate if in_path does not exist, and SyntaxError if
+    in_path cannot be parsed.
+    """
+    source = in_path.read_text()
+    return _resolve_ast_node_from_source(
+        name_path=name_path, source=source, in_path=in_path
+    )
+
+
+def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
+    """Return the 0-indexed (line, character) position of the name token for name_path.
+
+    Follows LSP convention: both line and character are 0-indexed.
+    For def/async def/class, character points past the keyword to the identifier.
+    For assignments and type aliases, character points at the start of the target name.
+    Raises SymbolNotFound, FileNotFoundError, and SyntaxError under the same
+    conditions as resolve_ast_node.
+    """
+    node = resolve_ast_node(name_path, in_path)
+    if isinstance(node, ast.FunctionDef):
+        return (node.lineno - 1, node.col_offset + len("def "))
+    if isinstance(node, ast.AsyncFunctionDef):
+        return (node.lineno - 1, node.col_offset + len("async def "))
+    if isinstance(node, ast.ClassDef):
+        return (node.lineno - 1, node.col_offset + len("class "))
+    if isinstance(node, ast.AnnAssign):
+        return (node.target.lineno - 1, node.target.col_offset)
+    if isinstance(node, ast.Assign):
+        return (node.targets[0].lineno - 1, node.targets[0].col_offset)
+    if isinstance(node, ast.TypeAlias):
+        return (node.name.lineno - 1, node.name.col_offset)
+    node_type = type(node).__name__
+    raise UnsupportedNamePath(
+        f"Cannot extract name position from {node_type} for {str(name_path)!r}"
+    )
+
+
+def _resolve_ast_node_from_source(
+    *,
+    name_path: NamePath,
+    source: str,
+    in_path: Path,
+) -> ast.stmt:
+    tree = ast.parse(source, filename=str(in_path))
+    head = name_path.head
+    tail = name_path.tail
+
+    top_match: ast.stmt | None = None
+
+    for node in ast.iter_child_nodes(tree):
+        matches_class = isinstance(node, ast.ClassDef) and node.name == head
+        matches_function = (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and tail is None
+            and node.name == head
+        )
+        if matches_class or matches_function:
+            top_match = node
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)) and tail is None:
+            name = assign_target_name(node)
+            if name == head:
+                top_match = node
+        elif isinstance(node, ast.TypeAlias) and tail is None and node.name.id == head:
+            top_match = node
+
+    if top_match is None:
+        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
+
+    if tail is not None and isinstance(top_match, ast.ClassDef):
+        return _resolve_class_member(
+            name_path=name_path,
+            in_path=in_path,
+            class_node=top_match,
+            member_name=tail,
+        )
+
+    return top_match
+
+
+def _resolve_class_member(
+    *,
+    name_path: NamePath,
+    in_path: Path,
+    class_node: ast.ClassDef,
+    member_name: str,
+) -> ast.stmt:
+    match: ast.stmt | None = None
+
+    for node in ast.iter_child_nodes(class_node):
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            name = assign_target_name(node)
+            if name == member_name:
+                match = node
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            kind = property_kind(node)
+            if kind in ("setter", "deleter"):
+                continue
+            if node.name == member_name:
+                match = node
+
+    if match is None:
+        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
+
+    return match

--- a/src/uncoded/serena_setup.py
+++ b/src/uncoded/serena_setup.py
@@ -82,6 +82,7 @@ SERENA_PROJECT_FIELDS = {
     "excluded_tools": [
         "execute_shell_command",
         "find_symbol",
+        "find_referencing_symbols",
         "list_memories",
         "read_memory",
         "write_memory",
@@ -97,7 +98,6 @@ SERENA_PROJECT_FIELDS = {
 
 SERENA_ALLOWED_TOOLS = [
     "mcp__serena__initial_instructions",
-    "mcp__serena__find_referencing_symbols",
     "mcp__serena__get_symbols_overview",
     "mcp__serena__rename_symbol",
     "mcp__serena__safe_delete_symbol",

--- a/src/uncoded/skill.py
+++ b/src/uncoded/skill.py
@@ -66,9 +66,8 @@ Verify by reading `.uncoded/namespace.yaml` — if it exists and is non-empty,
 proceed. If not, stop and tell the user to run `uncoded sync` first; the review
 depends on the index.
 
-If Serena MCP tools are available (`mcp__serena__*`), the structural sweep has
-more leverage. The review still works without Serena but will be weaker on
-cross-file reference checks.
+The structural sweep uses `uncoded refs` for cross-file reference checks —
+it ships with uncoded itself and is always available when the index is present.
 
 ## Workflow
 
@@ -186,8 +185,8 @@ during this sweep.
 
 ## Step 4: Structural sweep
 
-Combine the namespace with the import graph and, if available, Serena's
-reference resolution.
+Combine the namespace with the import graph and `uncoded refs` for
+cross-file reference resolution.
 
 **Overgrown public surfaces / god modules.** A module or class whose public
 namespace is much larger than its siblings, or spans obviously different
@@ -213,8 +212,8 @@ Check systematically, not by spot-check:
 2. Cross-reference with stub import sections — any symbol imported by another
    source module is live; remove it from the candidate list. This culls the
    obvious cases cheaply.
-3. For remaining candidates, use Serena's `find_referencing_symbols` to verify.
-   If Serena is unavailable, note findings as lower confidence.
+3. For remaining candidates, use `uncoded refs <name_path> --in <relative_path>`
+   to verify. Empty output confirms zero callers.
 4. Distinguish two sub-cases when reporting:
    - *No callers anywhere* — dead code; highest priority.
    - *Callers only in tests* — the symbol is tested but not used in source;

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 from uncoded.body import (
-    BodyNotFound,
+    SymbolNotFound,
     UnsupportedNamePath,
     resolve_ast_node,
     resolve_body,
@@ -139,7 +139,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text("def other(): pass\n")
 
-        with pytest.raises(BodyNotFound, match="missing"):
+        with pytest.raises(SymbolNotFound, match="missing"):
             resolve_body("missing", path)
 
     def test_file_not_found_propagates(self, tmp_path):
@@ -271,7 +271,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        with pytest.raises(BodyNotFound, match="first_only"):
+        with pytest.raises(SymbolNotFound, match="first_only"):
             resolve_body("Foo/first_only", path)
 
     def test_not_found_in_class(self, tmp_path):
@@ -283,7 +283,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        with pytest.raises(BodyNotFound, match="missing"):
+        with pytest.raises(SymbolNotFound, match="missing"):
             resolve_body("Foo/missing", path)
 
 
@@ -347,7 +347,7 @@ class TestResolveAstNode:
         path = tmp_path / "m.py"
         path.write_text("def other(): pass\n")
 
-        with pytest.raises(BodyNotFound, match="missing"):
+        with pytest.raises(SymbolNotFound, match="missing"):
             resolve_ast_node("missing", path)
 
     def test_raises_unsupported_name_path(self, tmp_path):

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1,5 +1,6 @@
 import ast
 import textwrap
+from unittest import mock
 
 import pytest
 
@@ -449,6 +450,16 @@ class TestResolveNamePosition:
         path.write_text(source)
 
         assert resolve_name_position("Dog/bark", path) == (1, 8)
+
+    def test_unexpected_node_type_raises_unsupported_name_path(self, tmp_path):
+        path = tmp_path / "m.py"
+        path.write_text("pass\n")
+
+        with (
+            mock.patch("uncoded.body.resolve_ast_node", return_value=ast.Pass()),
+            pytest.raises(UnsupportedNamePath),
+        ):
+            resolve_name_position("anything", path)
 
 
 class TestResolveBodyByteIdentical:

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -5,8 +5,10 @@ from unittest import mock
 import pytest
 
 from uncoded.body import (
+    NamePath,
     SymbolNotFound,
     UnsupportedNamePath,
+    parse_name_path,
     resolve_ast_node,
     resolve_body,
     resolve_name_position,
@@ -22,7 +24,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("foo", path)
+        result = resolve_body(NamePath("foo"), path)
 
         assert result == "def foo():\n    return 42\n"
 
@@ -37,7 +39,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("compute", path)
+        result = resolve_body(NamePath("compute"), path)
 
         assert result == "@functools.cache\ndef compute():\n    return 1\n"
 
@@ -49,7 +51,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("fetch", path)
+        result = resolve_body(NamePath("fetch"), path)
 
         assert result == "async def fetch():\n    return 0\n"
 
@@ -64,7 +66,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Engine", path)
+        result = resolve_body(NamePath("Engine"), path)
 
         assert result == source
 
@@ -75,7 +77,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("MAX", path)
+        result = resolve_body(NamePath("MAX"), path)
 
         assert result == "MAX: int = 100\n"
 
@@ -86,7 +88,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("TIMEOUT", path)
+        result = resolve_body(NamePath("TIMEOUT"), path)
 
         assert result == "TIMEOUT = 30\n"
 
@@ -97,7 +99,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("UserId", path)
+        result = resolve_body(NamePath("UserId"), path)
 
         assert result == "type UserId = int\n"
 
@@ -117,7 +119,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("process", path)
+        result = resolve_body(NamePath("process"), path)
 
         assert result == "def process(x):\n    return x\n"
 
@@ -131,7 +133,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("foo", path)
+        result = resolve_body(NamePath("foo"), path)
 
         assert result == "def foo():\n    return 42\n"
 
@@ -140,20 +142,20 @@ class TestResolveBodyTopLevel:
         path.write_text("def other(): pass\n")
 
         with pytest.raises(SymbolNotFound, match="missing"):
-            resolve_body("missing", path)
+            resolve_body(NamePath("missing"), path)
 
     def test_file_not_found_propagates(self, tmp_path):
         path = tmp_path / "nonexistent.py"
 
         with pytest.raises(FileNotFoundError):
-            resolve_body("foo", path)
+            resolve_body(NamePath("foo"), path)
 
     def test_syntax_error_propagates(self, tmp_path):
         path = tmp_path / "m.py"
         path.write_text("def broken(:\n")
 
         with pytest.raises(SyntaxError):
-            resolve_body("broken", path)
+            resolve_body(NamePath("broken"), path)
 
 
 class TestResolveBodyClassMember:
@@ -166,7 +168,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Dog/bark", path)
+        result = resolve_body(NamePath("Dog", "bark"), path)
 
         assert result == '    def bark(self):\n        print("woof")\n'
 
@@ -184,7 +186,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Config/path", path)
+        result = resolve_body(NamePath("Config", "path"), path)
 
         expected = "    @property\n    def path(self):\n        return self._path\n"
         assert result == expected
@@ -197,7 +199,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Counter/count", path)
+        result = resolve_body(NamePath("Counter", "count"), path)
 
         assert result == "    count: int = 0\n"
 
@@ -209,7 +211,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Config/debug", path)
+        result = resolve_body(NamePath("Config", "debug"), path)
 
         assert result == "    debug = False\n"
 
@@ -222,7 +224,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Config/timeout", path)
+        result = resolve_body(NamePath("Config", "timeout"), path)
 
         assert result == "    timeout = 30\n"
 
@@ -237,7 +239,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Documented/method", path)
+        result = resolve_body(NamePath("Documented", "method"), path)
 
         assert result == "    def method(self):\n        pass\n"
 
@@ -254,7 +256,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("Foo/second_only", path)
+        result = resolve_body(NamePath("Foo", "second_only"), path)
 
         assert result == "    def second_only(self):\n        pass\n"
 
@@ -272,7 +274,7 @@ class TestResolveBodyClassMember:
         path.write_text(source)
 
         with pytest.raises(SymbolNotFound, match="first_only"):
-            resolve_body("Foo/first_only", path)
+            resolve_body(NamePath("Foo", "first_only"), path)
 
     def test_not_found_in_class(self, tmp_path):
         source = textwrap.dedent("""\
@@ -284,17 +286,15 @@ class TestResolveBodyClassMember:
         path.write_text(source)
 
         with pytest.raises(SymbolNotFound, match="missing"):
-            resolve_body("Foo/missing", path)
+            resolve_body(NamePath("Foo", "missing"), path)
 
 
 class TestUnsupportedNamePath:
     SUPPORTED_SHAPES = ("'name'", "'Class/member'")
 
     def _assert_raises(self, name_path, tmp_path):
-        path = tmp_path / "m.py"
-        path.write_text("def foo(): pass\n")
         with pytest.raises(UnsupportedNamePath) as exc_info:
-            resolve_body(name_path, path)
+            parse_name_path(name_path)
         msg = str(exc_info.value)
         for shape in self.SUPPORTED_SHAPES:
             assert shape in msg
@@ -324,7 +324,7 @@ class TestResolveAstNode:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        node = resolve_ast_node("compute", path)
+        node = resolve_ast_node(NamePath("compute"), path)
 
         assert isinstance(node, ast.FunctionDef)
         assert node.name == "compute"
@@ -338,7 +338,7 @@ class TestResolveAstNode:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        node = resolve_ast_node("Engine/start", path)
+        node = resolve_ast_node(NamePath("Engine", "start"), path)
 
         assert isinstance(node, ast.FunctionDef)
         assert node.name == "start"
@@ -348,25 +348,22 @@ class TestResolveAstNode:
         path.write_text("def other(): pass\n")
 
         with pytest.raises(SymbolNotFound, match="missing"):
-            resolve_ast_node("missing", path)
+            resolve_ast_node(NamePath("missing"), path)
 
-    def test_raises_unsupported_name_path(self, tmp_path):
-        path = tmp_path / "m.py"
-        path.write_text("def foo(): pass\n")
-
+    def test_raises_unsupported_name_path(self):
         with pytest.raises(UnsupportedNamePath):
-            resolve_ast_node("A/B/C", path)
+            parse_name_path("A/B/C")
 
     def test_file_not_found_propagates(self, tmp_path):
         with pytest.raises(FileNotFoundError):
-            resolve_ast_node("foo", tmp_path / "nonexistent.py")
+            resolve_ast_node(NamePath("foo"), tmp_path / "nonexistent.py")
 
     def test_syntax_error_propagates(self, tmp_path):
         path = tmp_path / "m.py"
         path.write_text("def broken(:\n")
 
         with pytest.raises(SyntaxError):
-            resolve_ast_node("broken", path)
+            resolve_ast_node(NamePath("broken"), path)
 
 
 class TestResolveNamePosition:
@@ -378,7 +375,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("compute", path) == (0, 4)
+        assert resolve_name_position(NamePath("compute"), path) == (0, 4)
 
     def test_function_decorator_does_not_shift_line(self, tmp_path):
         source = textwrap.dedent("""\
@@ -391,7 +388,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("compute", path) == (3, 4)
+        assert resolve_name_position(NamePath("compute"), path) == (3, 4)
 
     def test_async_function(self, tmp_path):
         source = textwrap.dedent("""\
@@ -401,7 +398,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("fetch", path) == (0, 10)
+        assert resolve_name_position(NamePath("fetch"), path) == (0, 10)
 
     def test_class(self, tmp_path):
         source = textwrap.dedent("""\
@@ -411,7 +408,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("Engine", path) == (0, 6)
+        assert resolve_name_position(NamePath("Engine"), path) == (0, 6)
 
     def test_annotated_assignment(self, tmp_path):
         source = textwrap.dedent("""\
@@ -420,7 +417,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("MAX", path) == (0, 0)
+        assert resolve_name_position(NamePath("MAX"), path) == (0, 0)
 
     def test_unannotated_assignment(self, tmp_path):
         source = textwrap.dedent("""\
@@ -429,7 +426,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("TIMEOUT", path) == (0, 0)
+        assert resolve_name_position(NamePath("TIMEOUT"), path) == (0, 0)
 
     def test_type_alias(self, tmp_path):
         source = textwrap.dedent("""\
@@ -438,7 +435,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("UserId", path) == (0, 5)
+        assert resolve_name_position(NamePath("UserId"), path) == (0, 5)
 
     def test_class_method(self, tmp_path):
         source = textwrap.dedent("""\
@@ -449,7 +446,7 @@ class TestResolveNamePosition:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        assert resolve_name_position("Dog/bark", path) == (1, 8)
+        assert resolve_name_position(NamePath("Dog", "bark"), path) == (1, 8)
 
     def test_unexpected_node_type_raises_unsupported_name_path(self, tmp_path):
         path = tmp_path / "m.py"
@@ -459,7 +456,7 @@ class TestResolveNamePosition:
             mock.patch("uncoded.body.resolve_ast_node", return_value=ast.Pass()),
             pytest.raises(UnsupportedNamePath),
         ):
-            resolve_name_position("anything", path)
+            resolve_name_position(NamePath("anything"), path)
 
 
 class TestResolveBodyByteIdentical:
@@ -469,6 +466,6 @@ class TestResolveBodyByteIdentical:
         path = tmp_path / "m.py"
         path.write_text(source)
 
-        result = resolve_body("compute", path)
+        result = resolve_body(NamePath("compute"), path)
 
         assert result == body

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -292,27 +292,27 @@ class TestResolveBodyClassMember:
 class TestUnsupportedNamePath:
     SUPPORTED_SHAPES = ("'name'", "'Class/member'")
 
-    def _assert_raises(self, name_path, tmp_path):
+    def _assert_raises(self, name_path):
         with pytest.raises(UnsupportedNamePath) as exc_info:
             parse_name_path(name_path)
         msg = str(exc_info.value)
         for shape in self.SUPPORTED_SHAPES:
             assert shape in msg
 
-    def test_three_segment_path(self, tmp_path):
-        self._assert_raises("A/B/C", tmp_path)
+    def test_three_segment_path(self):
+        self._assert_raises("A/B/C")
 
-    def test_nested_class_shape(self, tmp_path):
-        self._assert_raises("Outer/Inner/method", tmp_path)
+    def test_nested_class_shape(self):
+        self._assert_raises("Outer/Inner/method")
 
-    def test_empty_leading_segment(self, tmp_path):
-        self._assert_raises("/foo", tmp_path)
+    def test_empty_leading_segment(self):
+        self._assert_raises("/foo")
 
-    def test_empty_trailing_segment(self, tmp_path):
-        self._assert_raises("foo/", tmp_path)
+    def test_empty_trailing_segment(self):
+        self._assert_raises("foo/")
 
-    def test_empty_middle_segment(self, tmp_path):
-        self._assert_raises("foo//bar", tmp_path)
+    def test_empty_middle_segment(self):
+        self._assert_raises("foo//bar")
 
 
 class TestResolveAstNode:

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -4,13 +4,12 @@ from unittest import mock
 
 import pytest
 
-from uncoded.body import (
+from uncoded.body import resolve_body
+from uncoded.resolver import (
     NamePath,
     SymbolNotFound,
     UnsupportedNamePath,
-    parse_name_path,
     resolve_ast_node,
-    resolve_body,
     resolve_name_position,
 )
 
@@ -294,7 +293,7 @@ class TestUnsupportedNamePath:
 
     def _assert_raises(self, name_path):
         with pytest.raises(UnsupportedNamePath) as exc_info:
-            parse_name_path(name_path)
+            NamePath.parse(name_path)
         msg = str(exc_info.value)
         for shape in self.SUPPORTED_SHAPES:
             assert shape in msg
@@ -352,7 +351,7 @@ class TestResolveAstNode:
 
     def test_raises_unsupported_name_path(self):
         with pytest.raises(UnsupportedNamePath):
-            parse_name_path("A/B/C")
+            NamePath.parse("A/B/C")
 
     def test_file_not_found_propagates(self, tmp_path):
         with pytest.raises(FileNotFoundError):
@@ -453,7 +452,7 @@ class TestResolveNamePosition:
         path.write_text("pass\n")
 
         with (
-            mock.patch("uncoded.body.resolve_ast_node", return_value=ast.Pass()),
+            mock.patch("uncoded.resolver.resolve_ast_node", return_value=ast.Pass()),
             pytest.raises(UnsupportedNamePath),
         ):
             resolve_name_position(NamePath("anything"), path)

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -8,6 +8,7 @@ from uncoded.body import (
     UnsupportedNamePath,
     resolve_ast_node,
     resolve_body,
+    resolve_name_position,
 )
 
 
@@ -365,6 +366,89 @@ class TestResolveAstNode:
 
         with pytest.raises(SyntaxError):
             resolve_ast_node("broken", path)
+
+
+class TestResolveNamePosition:
+    def test_function(self, tmp_path):
+        source = textwrap.dedent("""\
+            def compute(x: int) -> int:
+                return x * 2
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("compute", path) == (0, 4)
+
+    def test_function_decorator_does_not_shift_line(self, tmp_path):
+        source = textwrap.dedent("""\
+            import functools
+
+            @functools.cache
+            def compute():
+                return 1
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("compute", path) == (3, 4)
+
+    def test_async_function(self, tmp_path):
+        source = textwrap.dedent("""\
+            async def fetch():
+                return 0
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("fetch", path) == (0, 10)
+
+    def test_class(self, tmp_path):
+        source = textwrap.dedent("""\
+            class Engine:
+                pass
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("Engine", path) == (0, 6)
+
+    def test_annotated_assignment(self, tmp_path):
+        source = textwrap.dedent("""\
+            MAX: int = 100
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("MAX", path) == (0, 0)
+
+    def test_unannotated_assignment(self, tmp_path):
+        source = textwrap.dedent("""\
+            TIMEOUT = 30
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("TIMEOUT", path) == (0, 0)
+
+    def test_type_alias(self, tmp_path):
+        source = textwrap.dedent("""\
+            type UserId = int
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("UserId", path) == (0, 5)
+
+    def test_class_method(self, tmp_path):
+        source = textwrap.dedent("""\
+            class Dog:
+                def bark(self):
+                    pass
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        assert resolve_name_position("Dog/bark", path) == (1, 8)
 
 
 class TestResolveBodyByteIdentical:

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1,8 +1,14 @@
+import ast
 import textwrap
 
 import pytest
 
-from uncoded.body import BodyNotFound, UnsupportedNamePath, resolve_body
+from uncoded.body import (
+    BodyNotFound,
+    UnsupportedNamePath,
+    resolve_ast_node,
+    resolve_body,
+)
 
 
 class TestResolveBodyTopLevel:
@@ -305,6 +311,60 @@ class TestUnsupportedNamePath:
 
     def test_empty_middle_segment(self, tmp_path):
         self._assert_raises("foo//bar", tmp_path)
+
+
+class TestResolveAstNode:
+    def test_returns_function_def_for_top_level_function(self, tmp_path):
+        source = textwrap.dedent("""\
+            def compute(x: int) -> int:
+                return x * 2
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        node = resolve_ast_node("compute", path)
+
+        assert isinstance(node, ast.FunctionDef)
+        assert node.name == "compute"
+
+    def test_returns_method_node_for_class_member(self, tmp_path):
+        source = textwrap.dedent("""\
+            class Engine:
+                def start(self):
+                    pass
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source)
+
+        node = resolve_ast_node("Engine/start", path)
+
+        assert isinstance(node, ast.FunctionDef)
+        assert node.name == "start"
+
+    def test_raises_body_not_found(self, tmp_path):
+        path = tmp_path / "m.py"
+        path.write_text("def other(): pass\n")
+
+        with pytest.raises(BodyNotFound, match="missing"):
+            resolve_ast_node("missing", path)
+
+    def test_raises_unsupported_name_path(self, tmp_path):
+        path = tmp_path / "m.py"
+        path.write_text("def foo(): pass\n")
+
+        with pytest.raises(UnsupportedNamePath):
+            resolve_ast_node("A/B/C", path)
+
+    def test_file_not_found_propagates(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            resolve_ast_node("foo", tmp_path / "nonexistent.py")
+
+    def test_syntax_error_propagates(self, tmp_path):
+        path = tmp_path / "m.py"
+        path.write_text("def broken(:\n")
+
+        with pytest.raises(SyntaxError):
+            resolve_ast_node("broken", path)
 
 
 class TestResolveBodyByteIdentical:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ contract.
 import sys
 import textwrap
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -523,3 +524,139 @@ class TestBodyCommand:
 
         assert exc.value.code == 2
         assert capsys.readouterr().err != ""
+
+
+class TestRefsCommand:
+    def test_happy_path_dispatch(self, tmp_path, monkeypatch, capsys):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def foo():\n    return 42\n")
+        (pkg / "b.py").write_text("from pkg.a import foo\nfoo()\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["uncoded", "refs", "foo", "--in", "pkg/a.py"])
+
+        assert cli.main() == 0
+        out = capsys.readouterr().out
+        assert "pkg/b.py:2:1" in out
+
+    def test_class_method_form(self, tmp_path, monkeypatch, capsys):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text(
+            textwrap.dedent("""\
+                class Dog:
+                    def bark(self):
+                        pass
+            """)
+        )
+        (pkg / "b.py").write_text(
+            "from pkg.a import Dog\nd = Dog()\nd.bark()\nd.bark()\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        assert cli._refs(name_path="Dog/bark", in_path="pkg/a.py") == 0
+        out = capsys.readouterr().out
+        lines = out.strip().splitlines()
+        assert len(lines) == 2
+        assert all("pkg/b.py" in line for line in lines)
+
+    def test_symbol_not_found_exits_one(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "m.py").write_text("def other(): pass\n")
+
+        assert cli._refs(name_path="missing", in_path="m.py") == 1
+        err = capsys.readouterr().err
+        assert "missing" in err
+        assert "m.py" in err
+
+    def test_file_not_found_exits_one(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+
+        assert cli._refs(name_path="fn", in_path="nonexistent.py") == 1
+        assert "nonexistent.py" in capsys.readouterr().err
+
+    def test_syntax_error_exits_one(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "m.py").write_text("def broken(:\n")
+
+        assert cli._refs(name_path="broken", in_path="m.py") == 1
+        assert "m.py" in capsys.readouterr().err
+
+    def test_works_without_project_root(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "a.py").write_text("def foo():\n    pass\n")
+        (tmp_path / "b.py").write_text("from a import foo\nfoo()\n")
+
+        assert cli._refs(name_path="foo", in_path="a.py") == 0
+        assert capsys.readouterr().err == ""
+
+    def test_in_path_resolves_relative_to_cwd(self, tmp_path, monkeypatch, capsys):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def foo():\n    pass\n")
+        (pkg / "b.py").write_text("from pkg.a import foo\nfoo()\n")
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        monkeypatch.chdir(subdir)
+
+        assert cli._refs(name_path="foo", in_path="../pkg/a.py") == 0
+        assert capsys.readouterr().err == ""
+
+    def test_unsupported_name_path_exits_one(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "m.py").write_text("def fn(): pass\n")
+
+        assert cli._refs(name_path="A/B/C", in_path="m.py") == 1
+        err = capsys.readouterr().err
+        assert "Error:" in err
+        assert "'name'" in err
+        assert "'Class/member'" in err
+
+    def test_missing_in_flag_exits_with_two(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["uncoded", "refs", "fn"])
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 2
+        assert capsys.readouterr().err != ""
+
+    def test_zero_references_exits_zero_with_empty_stdout(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "m.py").write_text("def uncalled():\n    pass\n")
+
+        assert cli._refs(name_path="uncalled", in_path="m.py") == 0
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert err == ""
+
+    def test_multiple_references_prints_sorted(self, tmp_path, monkeypatch, capsys):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def foo():\n    return 42\n")
+        (pkg / "b.py").write_text(
+            "from pkg.a import foo\nresult = foo()\nother = foo()\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        assert cli._refs(name_path="foo", in_path="pkg/a.py") == 0
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert len(lines) == 2
+        assert lines[0] == "pkg/b.py:2:10"
+        assert lines[1] == "pkg/b.py:3:9"
+
+    def test_lsp_failure_exits_one(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "m.py").write_text("def foo(): pass\n")
+
+        with mock.patch("uncoded.cli.find_refs", side_effect=RuntimeError("ty error")):
+            assert cli._refs(name_path="foo", in_path="m.py") == 1
+
+        assert "ty error" in capsys.readouterr().err

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -112,6 +112,19 @@ class TestFindRefs:
         assert refs[0].line == 2
         assert refs[0].col == 1
 
+    def test_path_with_spaces_is_not_percent_encoded(self, tmp_path):
+        root = tmp_path / "my project"
+        root.mkdir()
+        (root / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (root / "a.py").write_text("def foo():\n    pass\n")
+        (root / "b.py").write_text("from a import foo\nfoo()\n")
+
+        refs = find_refs("foo", root / "a.py")
+
+        assert len(refs) == 1
+        assert "%20" not in str(refs[0].rel_path)
+        assert " " in str(refs[0].rel_path)
+
 
 class TestToRelPath:
     def test_returns_relative_path_when_under_cwd(self, tmp_path, monkeypatch):

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,156 @@
+import io
+import json
+import subprocess
+from unittest import mock
+
+import pytest
+
+from uncoded.refs import (
+    Reference,
+    _find_root,
+    _read_message,
+    _read_response,
+    _run_exchange,
+    _terminate,
+    query_references,
+)
+
+
+def _lsp_stream(*msgs: dict) -> io.BytesIO:
+    """Build a BytesIO stream pre-loaded with LSP-framed messages."""
+    data = b""
+    for msg in msgs:
+        body = json.dumps(msg).encode("utf-8")
+        data += f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+    return io.BytesIO(data)
+
+
+def _init_response() -> dict:
+    return {"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}
+
+
+def _shutdown_response() -> dict:
+    return {"jsonrpc": "2.0", "id": 3, "result": None}
+
+
+class TestQueryReferences:
+    def test_finds_call_sites(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def foo():\n    return 42\n")
+        (pkg / "b.py").write_text(
+            "from pkg.a import foo\nresult = foo()\nother = foo()\n"
+        )
+
+        refs = query_references(pkg / "a.py", (0, 4))
+
+        assert len(refs) == 2
+        assert all(isinstance(r, Reference) for r in refs)
+        assert all(r.path == pkg / "b.py" for r in refs)
+        assert {r.line for r in refs} == {1, 2}
+
+    def test_returns_empty_list_when_no_references(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        m = tmp_path / "m.py"
+        m.write_text("# just a comment\ndef foo(): pass\n")
+
+        refs = query_references(m, (0, 2))
+
+        assert refs == []
+
+
+class TestRunExchange:
+    def test_lsp_error_raises(self, tmp_path):
+        in_path = tmp_path / "m.py"
+        in_path.write_text("def foo(): pass\n")
+
+        stdout = _lsp_stream(
+            _init_response(),
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "error": {"code": -32602, "message": "not open"},
+            },  # noqa: E501
+        )
+
+        with pytest.raises(RuntimeError, match="ty LSP error"):
+            _run_exchange(
+                stdin=io.BytesIO(),
+                stdout=stdout,
+                in_path=in_path,
+                position=(0, 4),
+                root=tmp_path,
+            )
+
+    def test_empty_result_list_returns_empty(self, tmp_path):
+        in_path = tmp_path / "m.py"
+        in_path.write_text("def foo(): pass\n")
+
+        stdout = _lsp_stream(
+            _init_response(),
+            {"jsonrpc": "2.0", "id": 2, "result": []},
+            _shutdown_response(),
+        )
+
+        refs = _run_exchange(
+            stdin=io.BytesIO(),
+            stdout=stdout,
+            in_path=in_path,
+            position=(0, 4),
+            root=tmp_path,
+        )
+
+        assert refs == []
+
+
+class TestFindRoot:
+    def test_returns_pyproject_parent_when_found(self, tmp_path):
+        sub = tmp_path / "pkg"
+        sub.mkdir()
+        (tmp_path / "pyproject.toml").write_text("")
+
+        assert _find_root(sub / "m.py") == tmp_path
+
+    def test_returns_in_path_parent_when_not_found(self, tmp_path):
+        sub = tmp_path / "pkg"
+        sub.mkdir()
+
+        assert _find_root(sub / "m.py") == sub
+
+
+class TestTerminate:
+    def test_kills_on_timeout(self):
+        proc = mock.Mock(spec=subprocess.Popen)
+        proc.wait.side_effect = [subprocess.TimeoutExpired("cmd", 5), None]
+
+        _terminate(proc=proc)
+
+        proc.terminate.assert_called_once()
+        assert proc.wait.call_count == 2
+
+
+class TestReadMessage:
+    def test_raises_on_closed_stream(self):
+        with pytest.raises(RuntimeError, match="closed"):
+            _read_message(stream=io.BytesIO(b""))
+
+    def test_parses_framed_message(self):
+        msg = {"jsonrpc": "2.0", "id": 1, "result": {}}
+        body = json.dumps(msg).encode("utf-8")
+        data = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+
+        assert _read_message(stream=io.BytesIO(data)) == msg
+
+
+class TestReadResponse:
+    def test_skips_notifications_until_matching_id(self):
+        notification = {
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {},
+        }
+        response = {"jsonrpc": "2.0", "id": 7, "result": []}
+        stream = _lsp_stream(notification, response)
+
+        assert _read_response(stream=stream, request_id=7) == response

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 
+from uncoded.body import NamePath
 from uncoded.refs import (
     Reference,
     _find_root,
@@ -45,7 +46,7 @@ class TestFindRefs:
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
         (pkg / "a.py").write_text("def uncalled():\n    pass\n")
 
-        refs = find_refs("uncalled", pkg / "a.py")
+        refs = find_refs(NamePath("uncalled"), pkg / "a.py")
 
         assert refs == []
 
@@ -58,7 +59,7 @@ class TestFindRefs:
             "from pkg.a import foo\nresult = foo()\nother = foo()\n"
         )
 
-        refs = find_refs("foo", pkg / "a.py")
+        refs = find_refs(NamePath("foo"), pkg / "a.py")
 
         assert len(refs) == 2
         assert all(isinstance(r, Reference) for r in refs)
@@ -81,7 +82,7 @@ class TestFindRefs:
             "from pkg.a import Dog\nd = Dog()\nd.bark()\nd.bark()\n"
         )
 
-        refs = find_refs("Dog/bark", pkg / "a.py")
+        refs = find_refs(NamePath("Dog", "bark"), pkg / "a.py")
 
         assert len(refs) == 2
         assert all(r.rel_path == pkg / "b.py" for r in refs)
@@ -95,7 +96,7 @@ class TestFindRefs:
             "from pkg.a import foo\nresult = foo()\nother = foo()\n"
         )
 
-        refs = find_refs("foo", pkg / "a.py")
+        refs = find_refs(NamePath("foo"), pkg / "a.py")
 
         assert refs == sorted(refs, key=lambda r: (r.rel_path, r.line, r.col))
 
@@ -106,7 +107,7 @@ class TestFindRefs:
         (pkg / "a.py").write_text("def foo():\n    return 42\n")
         (pkg / "b.py").write_text("from pkg.a import foo\nfoo()\n")
 
-        refs = find_refs("foo", pkg / "a.py")
+        refs = find_refs(NamePath("foo"), pkg / "a.py")
 
         assert len(refs) == 1
         assert refs[0].line == 2
@@ -119,7 +120,7 @@ class TestFindRefs:
         (root / "a.py").write_text("def foo():\n    pass\n")
         (root / "b.py").write_text("from a import foo\nfoo()\n")
 
-        refs = find_refs("foo", root / "a.py")
+        refs = find_refs(NamePath("foo"), root / "a.py")
 
         assert len(refs) == 1
         assert "%20" not in str(refs[0].rel_path)

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -182,6 +182,7 @@ class TestRunExchange:
                 "id": 2,
                 "error": {"code": -32602, "message": "not open"},
             },
+            _shutdown_response(),
         )
 
         with pytest.raises(RuntimeError, match="ty LSP error"):

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -7,7 +7,6 @@ from unittest import mock
 
 import pytest
 
-from uncoded.body import NamePath
 from uncoded.refs import (
     Reference,
     _find_root,
@@ -20,6 +19,7 @@ from uncoded.refs import (
     find_refs,
     query_references,
 )
+from uncoded.resolver import NamePath
 
 
 def _lsp_stream(*msgs: dict) -> io.BytesIO:

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,6 +1,8 @@
 import io
 import json
 import subprocess
+import textwrap
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -8,10 +10,13 @@ import pytest
 from uncoded.refs import (
     Reference,
     _find_root,
+    _LSPLocation,
     _read_message,
     _read_response,
     _run_exchange,
     _terminate,
+    _to_rel_path,
+    find_refs,
     query_references,
 )
 
@@ -33,6 +38,101 @@ def _shutdown_response() -> dict:
     return {"jsonrpc": "2.0", "id": 3, "result": None}
 
 
+class TestFindRefs:
+    def test_returns_empty_for_dead_symbol(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def uncalled():\n    pass\n")
+
+        refs = find_refs("uncalled", pkg / "a.py")
+
+        assert refs == []
+
+    def test_finds_multiple_references_across_files(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def foo():\n    return 42\n")
+        (pkg / "b.py").write_text(
+            "from pkg.a import foo\nresult = foo()\nother = foo()\n"
+        )
+
+        refs = find_refs("foo", pkg / "a.py")
+
+        assert len(refs) == 2
+        assert all(isinstance(r, Reference) for r in refs)
+        assert all(r.rel_path == pkg / "b.py" for r in refs)
+        assert [r.line for r in refs] == [2, 3]
+        assert all(r.col >= 1 for r in refs)
+
+    def test_class_method_shape(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text(
+            textwrap.dedent("""\
+            class Dog:
+                def bark(self):
+                    pass
+        """)
+        )
+        (pkg / "b.py").write_text(
+            "from pkg.a import Dog\nd = Dog()\nd.bark()\nd.bark()\n"
+        )
+
+        refs = find_refs("Dog/bark", pkg / "a.py")
+
+        assert len(refs) == 2
+        assert all(r.rel_path == pkg / "b.py" for r in refs)
+
+    def test_results_are_sorted(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def foo():\n    return 42\n")
+        (pkg / "b.py").write_text(
+            "from pkg.a import foo\nresult = foo()\nother = foo()\n"
+        )
+
+        refs = find_refs("foo", pkg / "a.py")
+
+        assert refs == sorted(refs, key=lambda r: (r.rel_path, r.line, r.col))
+
+    def test_line_and_col_are_one_indexed(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
+        (pkg / "a.py").write_text("def foo():\n    return 42\n")
+        (pkg / "b.py").write_text("from pkg.a import foo\nfoo()\n")
+
+        refs = find_refs("foo", pkg / "a.py")
+
+        assert len(refs) == 1
+        assert refs[0].line == 2
+        assert refs[0].col == 1
+
+
+class TestToRelPath:
+    def test_returns_relative_path_when_under_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / "pkg" / "m.py"
+
+        result = _to_rel_path(path=path)
+
+        assert result == Path("pkg/m.py")
+
+    def test_returns_absolute_path_when_outside_cwd(self, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.chdir(workspace)
+        other = tmp_path / "elsewhere" / "m.py"
+
+        result = _to_rel_path(path=other)
+
+        assert result == other
+
+
 class TestQueryReferences:
     def test_finds_call_sites(self, tmp_path):
         pkg = tmp_path / "pkg"
@@ -46,7 +146,7 @@ class TestQueryReferences:
         refs = query_references(pkg / "a.py", (0, 4))
 
         assert len(refs) == 2
-        assert all(isinstance(r, Reference) for r in refs)
+        assert all(isinstance(r, _LSPLocation) for r in refs)
         assert all(r.path == pkg / "b.py" for r in refs)
         assert {r.line for r in refs} == {1, 2}
 
@@ -71,7 +171,7 @@ class TestRunExchange:
                 "jsonrpc": "2.0",
                 "id": 2,
                 "error": {"code": -32602, "message": "not open"},
-            },  # noqa: E501
+            },
         )
 
         with pytest.raises(RuntimeError, match="ty LSP error"):

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -173,6 +173,10 @@ class TestQueryReferences:
         ):
             query_references(in_path, (0, 4))
 
+    def test_relative_path_raises_value_error(self):
+        with pytest.raises(ValueError, match="absolute path"):
+            query_references(Path("relative/m.py"), (0, 0))
+
     def test_returns_empty_list_when_no_references(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
         m = tmp_path / "m.py"

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -150,6 +150,16 @@ class TestQueryReferences:
         assert all(r.path == pkg / "b.py" for r in refs)
         assert {r.line for r in refs} == {1, 2}
 
+    def test_uvx_not_found_raises_runtime_error(self, tmp_path):
+        in_path = tmp_path / "m.py"
+        in_path.write_text("def foo(): pass\n")
+
+        with (
+            mock.patch("uncoded.refs.subprocess.Popen", side_effect=FileNotFoundError),
+            pytest.raises(RuntimeError, match="uvx not found"),
+        ):
+            query_references(in_path, (0, 4))
+
     def test_returns_empty_list_when_no_references(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "t"\n')
         m = tmp_path / "m.py"

--- a/tests/test_serena_setup.py
+++ b/tests/test_serena_setup.py
@@ -19,6 +19,7 @@ REPO_ROOT = Path(__file__).parent.parent
 EXPECTED_EXCLUDED_TOOLS = {
     "execute_shell_command",
     "find_symbol",
+    "find_referencing_symbols",
     "list_memories",
     "read_memory",
     "write_memory",


### PR DESCRIPTION
Step 2 of #111's migration from Serena/MCP to native uncoded CLIs, plus the matching dispatch-rule cutover. After step 1 added `uncoded body` (#132), this step adds `uncoded refs` for impact analysis — find every reference to a named symbol — and removes `find_referencing_symbols` from Serena's exposed surface in this repo.

Each `uncoded refs` invocation spawns a fresh `ty server` over stdio, opens the file from disk, queries `textDocument/references`, and exits. No long-lived LSP buffer to go stale — the class of bug behind #46 doesn't exist on this path.

The agent dispatch rule across `_SECTION_BODY`, `README.md`, `_SKILL_CONTENT`, and AGENTS.md's hand-written preamble now routes the "find callers" step to `uncoded refs`. Serena's role narrows to renaming, editing by symbol, and safe-deletion. Serena's surface is closed in two layers: `find_referencing_symbols` is removed from `SERENA_ALLOWED_TOOLS` and added to `excluded_tools` in `SERENA_PROJECT_FIELDS` — the same defence-in-depth shape `find_symbol` follows after #140.

Internally the AST walker that maps `name_path` to `ast.stmt` was lifted from `body.py` into a shared helper so `body` and `refs` share it. Source is read once per public-function call.

`ty` pinned at 0.0.37. The remaining Serena tools (rename, safe-delete, edit-by-symbol) plus `serena_setup.py` and `SERENA_VERSION` are out of scope here — they belong to step 5 of #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)