### PR TITLE
GH194: tie skill auto-load to an action, as a checklist

### DIFF
--- a/.uncoded/docs.yaml
+++ b/.uncoded/docs.yaml
@@ -29,4 +29,4 @@ AGENTS.md:
     Approach:
     Commands:
     Docstrings:
-    Skills:
+    Before you start:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ uv run pytest tests/test_stubs.py --no-cov
 Public symbols need a pep257 plain-prose docstring. Magic methods are included.
 Private symbols (underscore-prefixed) and test code are exempt.
 
-## Skills
+## Before you start
 
-Always load the `uncoded-code-navigation` and `uncoded-doc-navigation` skills.
+- Load the `uncoded-code-navigation` skill before searching, reading or editing
+  any code.
+- Load the `uncoded-doc-navigation` skill before searching, reading or editing
+  any docs.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ Markdown.
   and incoherence (see [Coherence review](#coherence-review)). Generated when
   `source-roots` is configured.
 
-Skills are on-demand by default. To have the navigation skills loaded every
-session, add one line to your `AGENTS.md` or `CLAUDE.md`:
+Add these lines to your `AGENTS.md` or `CLAUDE.md` to load the navigation skills
+every session. Skills are on-demand by default. Tying the load to an action
+agents are about to take prompts them to act on it:
 
 ```text
-Always load the `uncoded-code-navigation` and `uncoded-doc-navigation` skills.
+## Before you start
+
+- Load the `uncoded-code-navigation` skill before searching, reading or editing any code.
+- Load the `uncoded-doc-navigation` skill before searching, reading or editing any docs.
 ```
 
 ## Install uv
@@ -325,11 +329,14 @@ upgrading:
    `.uncoded.toml` has it. uncoded no longer reads this key. Leaving it in place
    causes no error.
 
-4. **Restore always-on navigation** if you want v1 behaviour back. Add one line
-   to your `AGENTS.md` and `CLAUDE.md`:
+4. **Restore always-on navigation** if you want v1 behaviour back. Add these
+   lines to your `AGENTS.md` and `CLAUDE.md`:
 
    ```text
-   Always load the `uncoded-code-navigation` and `uncoded-doc-navigation` skills.
+   ## Before you start
+
+   - Load the `uncoded-code-navigation` skill before searching, reading or editing any code.
+   - Load the `uncoded-doc-navigation` skill before searching, reading or editing any docs.
    ```
 
 ## Releasing


### PR DESCRIPTION
Fixes #194.

## Problem

uncoded tells users to add `Always load the uncoded-code-navigation and uncoded-doc-navigation skills.` to `AGENTS.md`/`CLAUDE.md` for always-on skill loading. The instruction does not reliably cause loading. An agent that reads the file may still not act on the line (observed in #189). This is distinct from #183 (Explore/Plan subagents structurally skipping `CLAUDE.md`).

## Change

Reword the recommended instruction so it:

1. **Ties each load to an action** the agent is about to take. The wording is `Load the … skill before searching, reading or editing any code/docs.`
2. **Presents the two loads as a bulleted checklist** under a `## Before you start` heading, framing each as a discrete directive to act on.

```text
## Before you start

- Load the `uncoded-code-navigation` skill before searching, reading or editing any code.
- Load the `uncoded-doc-navigation` skill before searching, reading or editing any docs.
```

Applied in three places:

- `AGENTS.md` (and `CLAUDE.md`, a symlink to it): the repo's live instruction, with the old `## Skills` section renamed.
- `README.md`: both recommendation sites, the "Skills" how-to and "Upgrading from v1" step 4.
- `.uncoded/docs.yaml`: regenerated for the renamed heading.

This follows the direction suggested in the issue discussion, with the verb leading the instruction.

## Verification

- `uv run uncoded check` passes. The index is up to date.
- pre-commit hooks pass (markdownlint, prettier, ty, uncoded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)