### PR TITLE
Modernise ruff hook and expand ruff check selection (phases 1-3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,10 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.19
     hooks:
-      - id: ruff
-        args: [--fix]
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix, --show-fixes]
       - id: ruff-format
 
   - repo: local

--- a/.uncoded/docs.yaml
+++ b/.uncoded/docs.yaml
@@ -28,5 +28,6 @@ AGENTS.md:
     Problem:
     Approach:
     Commands:
+    Linting and formatting:
     Docstrings:
     Before you start:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,22 @@ uv run pytest
 uv run pytest tests/test_stubs.py --no-cov
 ```
 
+## Linting and formatting
+
+Run `ruff check --fix` and `ruff format` before committing. The pre-commit hooks
+run the same fixes automatically. If a hook rewrites files, the commit fails.
+Re-stage the modified files and commit again. The uncoded sync hook follows the
+same pattern.
+
+Never commit with `--no-verify`. CI runs `pre-commit run --all-files` on every
+pull request and will fail a build where a hook was skipped.
+
+Do not pass `--unsafe-fixes` unless a specific violation needs it and you have
+reviewed the change.
+
+A C901 violation means a function is too complex to pass the check. Refactor or
+flatten it rather than raising the `max-complexity` threshold.
+
 ## Docstrings
 
 Public symbols need a pep257 plain-prose docstring. Magic methods are included.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,21 +63,21 @@ extend-exclude = [".uncoded"]
 
 [tool.ruff.lint]
 select = [
-    "D",    # pydocstyle (pep257)
-    "E",    # pycodestyle errors
-    "F",    # pyflakes
-    "I",    # isort
-    "UP",   # pyupgrade
-    "B",    # flake8-bugbear
-    "SIM",  # flake8-simplify
+    "D", # pydocstyle (pep257)
+    "E", # pycodestyle errors
+    "F", # pyflakes
+    "I", # isort
+    "UP", # pyupgrade
+    "B", # flake8-bugbear
+    "SIM", # flake8-simplify
     "C901", # mccabe complexity
-    "W",    # pycodestyle warnings
-    "C4",   # flake8-comprehensions
-    "PIE",  # flake8-pie (misc. lints)
-    "FLY",  # flynt (f-string conversion)
+    "W", # pycodestyle warnings
+    "C4", # flake8-comprehensions
+    "PIE", # flake8-pie (misc. lints)
+    "FLY", # flynt (f-string conversion)
     "PERF", # perflint (performance anti-patterns)
-    "RUF",  # Ruff-specific rules
-    "PLE",  # Pylint errors
+    "RUF", # Ruff-specific rules
+    "PLE", # Pylint errors
     "PLW2901", # Pylint: redefined loop variable
     "PLC0415", # Pylint: import not at top of file
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ select = [
     "PLE", # Pylint errors
     "PLW2901", # Pylint: redefined loop variable
     "PLC0415", # Pylint: import not at top of file
+    "TC", # flake8-type-checking
+    "TID", # flake8-tidy-imports
+    "PTH", # flake8-use-pathlib
 ]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,14 +63,20 @@ extend-exclude = [".uncoded"]
 
 [tool.ruff.lint]
 select = [
-    "D",  # pydocstyle (pep257)
-    "E",  # pycodestyle errors
-    "F",  # pyflakes
-    "I",  # isort
-    "UP", # pyupgrade
-    "B",  # flake8-bugbear
-    "SIM", # flake8-simplify
+    "D",    # pydocstyle (pep257)
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
     "C901", # mccabe complexity
+    "W",    # pycodestyle warnings
+    "C4",   # flake8-comprehensions
+    "PIE",  # flake8-pie (misc. lints)
+    "FLY",  # flynt (f-string conversion)
+    "PERF", # perflint (performance anti-patterns)
+    "RUF",  # Ruff-specific rules
 ]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ select = [
     "FLY",  # flynt (f-string conversion)
     "PERF", # perflint (performance anti-patterns)
     "RUF",  # Ruff-specific rules
+    "PLE",  # Pylint errors
+    "PLW2901", # Pylint: redefined loop variable
+    "PLC0415", # Pylint: import not at top of file
 ]
 
 [tool.ruff.lint.mccabe]

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -77,17 +77,16 @@ def _sync_code_artefacts(
         )
         return n
 
-    source_roots: list[Path] = []
-    for configured in configured_source_roots:
-        source_roots.append(
-            _validate_root(
-                configured,
-                kind="source",
-                project_root=project_root,
-                resolved_project_root=resolved_project_root,
-                accepts_md_file=False,
-            )
+    source_roots = [
+        _validate_root(
+            configured,
+            kind="source",
+            project_root=project_root,
+            resolved_project_root=resolved_project_root,
+            accepts_md_file=False,
         )
+        for configured in configured_source_roots
+    ]
 
     roots_with_files = [
         (src_root, list(iter_source_files(src_root, project_root=project_root)))
@@ -130,17 +129,16 @@ def _sync_doc_artefacts(
         return remove_file(
             Path(".uncoded/docs.yaml"), project_root=project_root, check=check
         )
-    doc_roots: list[Path] = []
-    for configured in configured_doc_roots:
-        doc_roots.append(
-            _validate_root(
-                configured,
-                kind="doc",
-                project_root=project_root,
-                resolved_project_root=resolved_project_root,
-                accepts_md_file=True,
-            )
+    doc_roots = [
+        _validate_root(
+            configured,
+            kind="doc",
+            project_root=project_root,
+            resolved_project_root=resolved_project_root,
+            accepts_md_file=True,
         )
+        for configured in configured_doc_roots
+    ]
     all_doc_files = []
     for dr in doc_roots:
         all_doc_files.extend(iter_doc_files(dr, project_root))

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -139,9 +139,7 @@ def _sync_doc_artefacts(
         )
         for configured in configured_doc_roots
     ]
-    all_doc_files = []
-    for dr in doc_roots:
-        all_doc_files.extend(iter_doc_files(dr, project_root))
+    all_doc_files = [f for dr in doc_roots for f in iter_doc_files(dr, project_root)]
     docs_content = render_docs_map(build_docs_map(all_doc_files))
     return sync_file(
         Path(".uncoded/docs.yaml"),

--- a/src/uncoded/docs_map.py
+++ b/src/uncoded/docs_map.py
@@ -26,7 +26,7 @@ def _parse_atx_heading(line: str) -> tuple[int, str] | None:
     level = 0
     while level < len(line) and line[level] == "#":
         level += 1
-    # Valid ATX: 1–6 # followed by exactly one space.
+    # Valid ATX: 1-6 # followed by exactly one space.
     if level > 6 or level >= len(line) or line[level] != " ":
         return None
     title = line[level + 1 :].strip()
@@ -42,7 +42,7 @@ def _parse_atx_heading(line: str) -> tuple[int, str] | None:
 def extract_headings(text: str) -> list[tuple[int, str]]:
     """Return the ATX headings in ``text`` as ordered (level, title) pairs.
 
-    Recognises ATX headings only: 1–6 ``#`` followed by a space and a
+    Recognises ATX headings only: 1-6 ``#`` followed by a space and a
     non-empty title. A trailing ``#`` run is stripped only when it forms
     a CommonMark closing sequence — preceded by whitespace, or the title
     consists entirely of ``#`` characters. A ``#`` attached to the final
@@ -69,7 +69,7 @@ def extract_headings(text: str) -> list[tuple[int, str]]:
                 fence_marker = ""
             continue
 
-        if line.startswith("```") or line.startswith("~~~"):
+        if line.startswith(("```", "~~~")):
             in_fence = True
             fence_marker = line[:3]
             continue

--- a/src/uncoded/namespace_map.py
+++ b/src/uncoded/namespace_map.py
@@ -47,7 +47,7 @@ def build_map(modules: list[ModuleInfo]) -> dict:
 
         for cls in module.classes:
             members = cls.attributes + cls.methods
-            file_entry[cls.name] = {m: None for m in members} if members else None
+            file_entry[cls.name] = dict.fromkeys(members) if members else None
 
         for func in module.functions:
             file_entry[func] = None

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -76,8 +76,8 @@ def _query_references(
         ) from exc
     try:
         return _run_exchange(
-            stdin=cast(IO[bytes], proc.stdin),
-            stdout=cast(IO[bytes], proc.stdout),
+            stdin=cast("IO[bytes]", proc.stdin),
+            stdout=cast("IO[bytes]", proc.stdout),
             in_path=in_path,
             position=position,
             root=root,

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -268,8 +268,7 @@ def _render_class(cls: StubClass) -> list[str]:
         lines.append("    ...")
         lines.append("")
         return lines
-    for attr in cls.attributes:
-        lines.append(_render_assignment(attr, indent="    "))
+    lines.extend(_render_assignment(attr, indent="    ") for attr in cls.attributes)
     if cls.attributes:
         lines.append("")
     for method in cls.methods:
@@ -286,8 +285,7 @@ def render_stub(module: StubModule) -> str:
         lines.extend(module.imports)
         lines.append("")
 
-    for const in module.constants:
-        lines.append(_render_assignment(const))
+    lines.extend(_render_assignment(const) for const in module.constants)
     if module.constants:
         lines.append("")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ class TestReadConfig:
     # --- pyproject.toml ---
 
     def test_raises_when_no_config_file(self, tmp_path):
-        with pytest.raises(ConfigError, match="No pyproject.toml"):
+        with pytest.raises(ConfigError, match=r"No pyproject\.toml"):
             read_config(start=tmp_path)
 
     def test_source_roots_read_from_pyproject(self, tmp_path):

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -86,7 +86,7 @@ class TestSyncSkills:
         assert f"<!-- {GENERATED_MARKER} -->" in content[frontmatter_close:]
 
     def test_returns_change_count_on_first_write(self, tmp_path):
-        # Two code-gated skills × two roots = 4 writes; doc-nav skipped (docs=False).
+        # Two code-gated skills x two roots = 4 writes; doc-nav skipped (docs=False).
         result = sync_skills(
             source=True, docs=False, project_root=tmp_path, check=False
         )

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -950,7 +950,7 @@ class TestRemoveAllStubs:
         assert not stubs_dir.exists()
 
     def test_removes_nested_structure(self, tmp_path):
-        stubs_dir, pyi = self._make_stubs(tmp_path, "src/pkg/bar.pyi")
+        stubs_dir, _pyi = self._make_stubs(tmp_path, "src/pkg/bar.pyi")
         changes = remove_all_stubs(
             Path(".uncoded/stubs"), project_root=tmp_path, check=False
         )


### PR DESCRIPTION
Maintenance session under umbrella #207 ("Expand ruff checks"). It modernises the ruff pre-commit hook, documents a lint/format policy for agents, and expands the ruff rule selection in three phases. uncoded's product behaviour does not change.

Closes #217
Closes #208
Closes #209
Closes #210

## Requirements Analysis

Session Type: maintenance. All four issues tune the repo's own lint tooling and agent-facing docs.

### Improvement goals (each a checkable property)

1. (#217) Modern ruff hook. The ruff pre-commit hook uses the `ruff-check` id, not the deprecated `ruff` alias, at a current pinned rev, with args `--fix`, `--exit-non-zero-on-fix`, `--show-fixes`. (stated)
2. (#217) Written lint/format policy for agents. AGENTS.md carries a lint/format section: run `ruff check --fix` and `ruff format` before committing, re-stage and re-commit when a fixing hook rewrites files, never `--no-verify`, and treat complexity violations as a signal to refactor rather than silence. (stated)
3. (#208) Phase 1 rules selected and clean. ruff selects `W`, `C4`, `PIE`, `FLY`, `PERF`, `RUF`, and the tree passes them. (stated)
4. (#209) Phase 2 rules selected and clean. ruff selects `PLE`, `PLW2901`, `PLC0415`, and the tree passes them. (stated)
5. (#210) Phase 3 rules selected and clean. ruff selects `TC`, `TID`, `PTH`, and the tree passes them. (stated)

### Preserved behaviour

- uncoded's product behaviour is unchanged: the index, stubs, docs map, `body`, and `refs` produce the same output. (assumed)
- The currently selected rule families stay selected: `D`, `E`, `F`, `I`, `UP`, `B`, `SIM`, `C901`. (stated)
- CI keeps gating via `pre-commit run --all-files`; the 100% branch-coverage gate, the pep257 docstring convention, and the `tests/** = ["D"]` ignore are untouched. (stated)
- The fixing-hook convention (`ruff --fix`, `ruff-format`, `prettier --write`, `uncoded sync`, `end-of-file-fixer` all write in place) is kept. (stated)

### Constraints

- Complexity threshold. `max-complexity` stays at 8. #207 authorises raising it to 10 only if a new rule genuinely fights `C901`. None of phases 1-3 are complexity counters, so this is unlikely to arise. The permanent agent policy added in goal 2 still says refactor rather than raise the threshold; the 8 to 10 allowance is a project-owner call, not an agent's default escape hatch. (stated, #207)
- Doc location. The lint/format section goes in AGENTS.md (CLAUDE.md is a symlink, and the file says "Edit AGENTS.md"). `uncoded sync` writes only to `.uncoded/` and the skill directories, so there is no uncoded-managed region inside AGENTS.md to work around. This corrects a premise in #217. (assumed)

### Out of session

The remaining umbrella phases (#211 through #216, including complexipy) are out of this session by the branch's choice of issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- dream:3.5.0 type:maintenance req:0 ca:0 scope:0 design:0 plan:0 challenge:no autopilot:from-code-analysis -->
