### PR TITLE
Expand ruff check selection (phases 4-8)

### DIFF
--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -95,8 +95,8 @@ src/:
         tail:
         parse:
         __str__:
-      SymbolNotFound:
-      UnsupportedNamePath:
+      SymbolNotFoundError:
+      UnsupportedNamePathError:
       resolve_ast_node:
       resolve_name_position:
       resolve_ast_node_from_source:
@@ -193,7 +193,7 @@ tests/:
       test_shadowed_class_member_found_in_last_definition:
       test_shadowed_class_member_not_found_in_last_definition:
       test_not_found_in_class:
-    TestUnsupportedNamePath:
+    TestUnsupportedNamePathError:
       SUPPORTED_SHAPES:
       _assert_raises:
       test_three_segment_path:

--- a/.uncoded/stubs/src/uncoded/cli.pyi
+++ b/.uncoded/stubs/src/uncoded/cli.pyi
@@ -11,7 +11,7 @@ from uncoded.docs_map import build_docs_map, iter_doc_files, render_docs_map
 from uncoded.extract import extract_modules, iter_source_files
 from uncoded.namespace_map import build_map, render_map
 from uncoded.refs import find_refs
-from uncoded.resolver import NamePath, SymbolNotFound, UnsupportedNamePath
+from uncoded.resolver import NamePath, SymbolNotFoundError, UnsupportedNamePathError
 from uncoded.skill import sync_skills
 from uncoded.stubs import build_stubs, remove_all_stubs
 from uncoded.sync import remove_file, sync_file

--- a/.uncoded/stubs/src/uncoded/resolver.pyi
+++ b/.uncoded/stubs/src/uncoded/resolver.pyi
@@ -29,8 +29,8 @@ class NamePath(NamedTuple):
     def __str__(self) -> str:
         ...
 
-class SymbolNotFound(Exception):
+class SymbolNotFoundError(Exception):
     ...
 
-class UnsupportedNamePath(Exception):
+class UnsupportedNamePathError(Exception):
     ...

--- a/.uncoded/stubs/src/uncoded/yaml_tree.pyi
+++ b/.uncoded/stubs/src/uncoded/yaml_tree.pyi
@@ -7,5 +7,5 @@ def render_yaml_tree(header: str, mapping: dict) -> str:
     ...
 
 class _CleanDumper(yaml.SafeDumper):
-    def increase_indent(self, flow, indentless):
+    def increase_indent(self, flow: bool, indentless: bool) -> None:
         ...

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -6,7 +6,7 @@ import textwrap
 from unittest import mock
 import pytest
 from uncoded.body import resolve_body
-from uncoded.resolver import NamePath, SymbolNotFound, UnsupportedNamePath, resolve_ast_node, resolve_name_position
+from uncoded.resolver import NamePath, SymbolNotFoundError, UnsupportedNamePathError, resolve_ast_node, resolve_name_position
 
 class TestResolveBodyTopLevel:
     def test_function_without_decorators(self, tmp_path):
@@ -76,7 +76,7 @@ class TestResolveBodyClassMember:
     def test_not_found_in_class(self, tmp_path):
         ...
 
-class TestUnsupportedNamePath:
+class TestUnsupportedNamePathError:
     SUPPORTED_SHAPES = ("'name'", "'Class/member'")
 
     def _assert_raises(self, name_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ select = [
     "PLR1702", # Pylint: too many nested blocks (preview)
     "ANN", # flake8-annotations
     "S", # flake8-bandit (security)
+    "PT", # flake8-pytest-style
+    "N", # pep8-naming
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,11 @@ select = [
     "PLR0913", # Pylint: too many arguments
     "PLR0915", # Pylint: too many statements
     "PLR1702", # Pylint: too many nested blocks (preview)
+    "ANN", # flake8-annotations
+]
+
+ignore = [
+    "ANN401", # Any as annotation type (too broad to enforce)
 ]
 
 [tool.ruff.lint.mccabe]
@@ -102,4 +107,4 @@ max-complexity = 8
 convention = "pep257"  # policy stated in "Docstrings" section of AGENTS.md
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["D"]
+"tests/**" = ["D", "ANN"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ line-length = 88
 extend-exclude = [".uncoded"]
 
 [tool.ruff.lint]
+preview = true
 select = [
     "D", # pydocstyle (pep257)
     "E", # pycodestyle errors
@@ -87,6 +88,11 @@ select = [
     "PLR5501", # Pylint: elif after return
     "PLR1711", # Pylint: useless return
     "PLR1714", # Pylint: repeated equality comparison
+    "PLR0911", # Pylint: too many return statements
+    "PLR0912", # Pylint: too many branches
+    "PLR0913", # Pylint: too many arguments
+    "PLR0915", # Pylint: too many statements
+    "PLR1702", # Pylint: too many nested blocks (preview)
 ]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ select = [
     "TC", # flake8-type-checking
     "TID", # flake8-tidy-imports
     "PTH", # flake8-use-pathlib
+    "RET", # flake8-return
+    "PLR5501", # Pylint: elif after return
+    "PLR1711", # Pylint: useless return
+    "PLR1714", # Pylint: repeated equality comparison
 ]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ select = [
     "PLR0915", # Pylint: too many statements
     "PLR1702", # Pylint: too many nested blocks (preview)
     "ANN", # flake8-annotations
+    "S", # flake8-bandit (security)
 ]
 
 ignore = [
@@ -107,4 +108,4 @@ max-complexity = 8
 convention = "pep257"  # policy stated in "Docstrings" section of AGENTS.md
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["D", "ANN"]
+"tests/**" = ["D", "ANN", "S101"]

--- a/src/uncoded/body.py
+++ b/src/uncoded/body.py
@@ -10,7 +10,7 @@ from uncoded.resolver import NamePath, resolve_ast_node_from_source
 def resolve_body(name_path: NamePath, in_path: Path) -> str:
     """Return the source text for the symbol named by name_path in in_path.
 
-    Raises SymbolNotFound if the symbol is not present. Lets OSError,
+    Raises SymbolNotFoundError if the symbol is not present. Lets OSError,
     UnicodeDecodeError, and SyntaxError propagate from the file read.
     """
     source = read_source_text(in_path)

--- a/src/uncoded/cli.py
+++ b/src/uncoded/cli.py
@@ -11,7 +11,7 @@ from uncoded.docs_map import build_docs_map, iter_doc_files, render_docs_map
 from uncoded.extract import extract_modules, iter_source_files
 from uncoded.namespace_map import build_map, render_map
 from uncoded.refs import find_refs
-from uncoded.resolver import NamePath, SymbolNotFound, UnsupportedNamePath
+from uncoded.resolver import NamePath, SymbolNotFoundError, UnsupportedNamePathError
 from uncoded.skill import sync_skills
 from uncoded.stubs import build_stubs, remove_all_stubs
 from uncoded.sync import remove_file, sync_file
@@ -226,9 +226,9 @@ def _report_lookup_error(exc: Exception, *, name_path: str, in_path: str) -> int
     path, symbol not found, file not found, and read/parse error.
     FileNotFoundError is checked before OSError because it subclasses it.
     """
-    if isinstance(exc, UnsupportedNamePath):
+    if isinstance(exc, UnsupportedNamePathError):
         print(f"Error: {exc}", file=sys.stderr)
-    elif isinstance(exc, SymbolNotFound):
+    elif isinstance(exc, SymbolNotFoundError):
         print(f"Error: {name_path!r} not found in {in_path}", file=sys.stderr)
     elif isinstance(exc, FileNotFoundError):
         print(f"Error: {in_path}: file not found.", file=sys.stderr)
@@ -248,8 +248,8 @@ def _body(*, name_path: str, in_path: str) -> int:
     try:
         body = resolve_body(NamePath.parse(name_path), target)
     except (
-        UnsupportedNamePath,
-        SymbolNotFound,
+        UnsupportedNamePathError,
+        SymbolNotFoundError,
         FileNotFoundError,
         OSError,
         UnicodeDecodeError,
@@ -276,8 +276,8 @@ def _refs(*, name_path: str, in_path: str) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     except (
-        UnsupportedNamePath,
-        SymbolNotFound,
+        UnsupportedNamePathError,
+        SymbolNotFoundError,
         FileNotFoundError,
         OSError,
         UnicodeDecodeError,

--- a/src/uncoded/extract.py
+++ b/src/uncoded/extract.py
@@ -39,7 +39,7 @@ def _extract_class_members(node: ast.ClassDef) -> ClassInfo:
                 attributes.append(name)
         elif isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
             kind = property_kind(n)
-            if kind == "setter" or kind == "deleter":
+            if kind in {"setter", "deleter"}:
                 continue
             if kind == "property":
                 attributes.append(n.name)

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -35,7 +35,7 @@ def find_refs(name_path: NamePath, in_path: Path) -> list[Reference]:
     references, and returns results with 1-indexed line/col sorted by
     (rel_path, line, col). rel_path is relative to the current working
     directory when possible; otherwise absolute.
-    Propagates SymbolNotFound from resolve_name_position. OSError,
+    Propagates SymbolNotFoundError from resolve_name_position. OSError,
     UnicodeDecodeError, and SyntaxError propagate from resolve_name_position
     and from read_source_text in the LSP exchange.
     """

--- a/src/uncoded/refs.py
+++ b/src/uncoded/refs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used to spawn the ty LSP server
 from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, cast
@@ -64,8 +64,8 @@ def _query_references(
     """
     root = _find_root(in_path)
     try:
-        proc = subprocess.Popen(
-            ["uvx", "--from", f"ty=={TY_VERSION}", "ty", "server"],
+        proc = subprocess.Popen(  # noqa: S603 -- fixed command vector; uvx resolved from PATH by design
+            ["uvx", "--from", f"ty=={TY_VERSION}", "ty", "server"],  # noqa: S607 -- uvx resolved from PATH by design
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,

--- a/src/uncoded/resolver.py
+++ b/src/uncoded/resolver.py
@@ -49,7 +49,7 @@ class UnsupportedNamePathError(Exception):
 def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
     """Return the ast.stmt for the symbol named by name_path in in_path.
 
-    Raises SymbolNotFound if the symbol is not present. Lets OSError,
+    Raises SymbolNotFoundError if the symbol is not present. Lets OSError,
     UnicodeDecodeError, and SyntaxError propagate from the file read.
     """
     source = read_source_text(in_path)
@@ -64,7 +64,7 @@ def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]
     Follows LSP convention: both line and character are 0-indexed.
     For def/async def/class, character points past the keyword to the identifier.
     For assignments and type aliases, character points at the start of the target name.
-    Raises SymbolNotFound, OSError, UnicodeDecodeError, and SyntaxError under
+    Raises SymbolNotFoundError, OSError, UnicodeDecodeError, and SyntaxError under
     the same conditions as resolve_ast_node.
     """
     node = resolve_ast_node(name_path, in_path)
@@ -98,7 +98,7 @@ def resolve_ast_node_from_source(
     file read. Callers that already have the source string call this directly
     to avoid reading in_path again. in_path is used only for ast.parse's
     filename argument and for error messages.
-    Raises SymbolNotFound if the symbol is not present; propagates SyntaxError
+    Raises SymbolNotFoundError if the symbol is not present; propagates SyntaxError
     if source cannot be parsed.
     """
     tree = ast.parse(source, filename=str(in_path))

--- a/src/uncoded/resolver.py
+++ b/src/uncoded/resolver.py
@@ -18,11 +18,11 @@ class NamePath(NamedTuple):
     def parse(cls, s: str) -> "NamePath":
         """Parse a raw name_path string into a validated NamePath.
 
-        Raises UnsupportedNamePath for more than two segments or any empty segment.
+        Raises UnsupportedNamePathError for more than two segments or any empty segment.
         """
         segments = s.split("/")
         if len(segments) > 2 or any(seg == "" for seg in segments):
-            raise UnsupportedNamePath(
+            raise UnsupportedNamePathError(
                 f"Unsupported name_path {s!r}: use 'name' or 'Class/member'"
             )
         head = segments[0]
@@ -34,11 +34,11 @@ class NamePath(NamedTuple):
         return f"{self.head}/{self.tail}" if self.tail is not None else self.head
 
 
-class SymbolNotFound(Exception):
+class SymbolNotFoundError(Exception):
     """Raised when name_path cannot be found in the given file."""
 
 
-class UnsupportedNamePath(Exception):
+class UnsupportedNamePathError(Exception):
     """Raised when name_path does not match a supported shape.
 
     Supported shapes are 'name' (one segment) or 'Class/member' (two segments),
@@ -81,7 +81,7 @@ def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]
     if isinstance(node, ast.TypeAlias):
         return (node.name.lineno - 1, node.name.col_offset)
     node_type = type(node).__name__
-    raise UnsupportedNamePath(
+    raise UnsupportedNamePathError(
         f"Cannot extract name position from {node_type} for {str(name_path)!r}"
     )
 
@@ -124,7 +124,7 @@ def resolve_ast_node_from_source(
             top_match = node
 
     if top_match is None:
-        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
+        raise SymbolNotFoundError(f"{str(name_path)!r} not found in {in_path}")
 
     if tail is not None and isinstance(top_match, ast.ClassDef):
         return _resolve_class_member(
@@ -159,6 +159,6 @@ def _resolve_class_member(
                 match = node
 
     if match is None:
-        raise SymbolNotFound(f"{str(name_path)!r} not found in {in_path}")
+        raise SymbolNotFoundError(f"{str(name_path)!r} not found in {in_path}")
 
     return match

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -182,7 +182,7 @@ def _extract_class(node: ast.ClassDef) -> StubClass:
                 attributes.append(assignment)
         elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             kind = property_kind(child)
-            if kind == "setter" or kind == "deleter":
+            if kind in {"setter", "deleter"}:
                 continue
             if kind == "property":
                 attributes.append(_property_attribute(child))

--- a/src/uncoded/yaml_tree.py
+++ b/src/uncoded/yaml_tree.py
@@ -6,7 +6,7 @@ import yaml
 class _CleanDumper(yaml.SafeDumper):
     """YAML dumper that indents list items and suppresses 'null' values."""
 
-    def increase_indent(self, flow=False, indentless=False):
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
         """Force list items to be indented relative to their parent key."""
         return super().increase_indent(flow, False)
 

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -7,8 +7,8 @@ import pytest
 from uncoded.body import resolve_body
 from uncoded.resolver import (
     NamePath,
-    SymbolNotFound,
-    UnsupportedNamePath,
+    SymbolNotFoundError,
+    UnsupportedNamePathError,
     resolve_ast_node,
     resolve_name_position,
 )
@@ -140,7 +140,7 @@ class TestResolveBodyTopLevel:
         path = tmp_path / "m.py"
         path.write_text("def other(): pass\n", encoding="utf-8")
 
-        with pytest.raises(SymbolNotFound, match="missing"):
+        with pytest.raises(SymbolNotFoundError, match="missing"):
             resolve_body(NamePath("missing"), path)
 
     def test_file_not_found_propagates(self, tmp_path):
@@ -282,7 +282,7 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source, encoding="utf-8")
 
-        with pytest.raises(SymbolNotFound, match="first_only"):
+        with pytest.raises(SymbolNotFoundError, match="first_only"):
             resolve_body(NamePath("Foo", "first_only"), path)
 
     def test_not_found_in_class(self, tmp_path):
@@ -294,15 +294,15 @@ class TestResolveBodyClassMember:
         path = tmp_path / "m.py"
         path.write_text(source, encoding="utf-8")
 
-        with pytest.raises(SymbolNotFound, match="missing"):
+        with pytest.raises(SymbolNotFoundError, match="missing"):
             resolve_body(NamePath("Foo", "missing"), path)
 
 
-class TestUnsupportedNamePath:
+class TestUnsupportedNamePathError:
     SUPPORTED_SHAPES = ("'name'", "'Class/member'")
 
     def _assert_raises(self, name_path):
-        with pytest.raises(UnsupportedNamePath) as exc_info:
+        with pytest.raises(UnsupportedNamePathError) as exc_info:
             NamePath.parse(name_path)
         msg = str(exc_info.value)
         for shape in self.SUPPORTED_SHAPES:
@@ -356,11 +356,11 @@ class TestResolveAstNode:
         path = tmp_path / "m.py"
         path.write_text("def other(): pass\n", encoding="utf-8")
 
-        with pytest.raises(SymbolNotFound, match="missing"):
+        with pytest.raises(SymbolNotFoundError, match="missing"):
             resolve_ast_node(NamePath("missing"), path)
 
     def test_raises_unsupported_name_path(self):
-        with pytest.raises(UnsupportedNamePath):
+        with pytest.raises(UnsupportedNamePathError):
             NamePath.parse("A/B/C")
 
     def test_file_not_found_propagates(self, tmp_path):
@@ -463,7 +463,7 @@ class TestResolveNamePosition:
 
         with (
             mock.patch("uncoded.resolver.resolve_ast_node", return_value=ast.Pass()),
-            pytest.raises(UnsupportedNamePath),
+            pytest.raises(UnsupportedNamePathError),
         ):
             resolve_name_position(NamePath("anything"), path)
 

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,6 +1,6 @@
 import io
 import json
-import subprocess
+import subprocess  # noqa: S404 -- subprocess mocked in tests for the ty LSP client
 import textwrap
 from pathlib import Path
 from unittest import mock

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -123,7 +123,7 @@ class TestExtractStub:
         assert module.classes[0].bases == []
 
     @pytest.mark.parametrize(
-        "source,expected",
+        ("source", "expected"),
         [
             pytest.param(
                 "def f(x): pass\n",
@@ -430,7 +430,7 @@ class TestRenderStub:
         assert "async def fetch():\n    ...\n" in render_stub(module)
 
     @pytest.mark.parametrize(
-        "params,expected",
+        ("params", "expected"),
         [
             pytest.param(
                 [StubParam("x")],

--- a/tools/check_encoding.py
+++ b/tools/check_encoding.py
@@ -38,7 +38,7 @@ def _open_mode(call: ast.Call, *, mode_position: int = 1) -> str | None:
     return None
 
 
-def _check_call(node: ast.Call, path: Path) -> str | None:
+def _check_call(node: ast.Call, path: Path) -> str | None:  # noqa: PLR0911 -- flat dispatch, one return per text-IO call shape
     func = node.func
     has_encoding = any(kw.arg == "encoding" for kw in node.keywords)
     if has_encoding:


### PR DESCRIPTION
Maintenance session under umbrella #207 ("Expand ruff checks"). It expands the ruff rule selection across phases 4-8 and fixes the resulting violations. uncoded's product behaviour does not change. Continues the work of #221 (phases 1-3).

Closes #211
Closes #212
Closes #213
Closes #214
Closes #215

## Requirements Analysis

Session Type: maintenance. Phases 4-8 of umbrella #207 expand the repo's own ruff rule selection and fix the resulting violations. uncoded's product behaviour does not change.

### Improvement goals (each a checkable property)

1. (#211, phase 4) ruff selects `RET`, `PLR5501`, `PLR1711`, `PLR1714`, and the tree passes. Real work: 2 `PLR1714` sites become `x in {...}`. (stated)
2. (#212, phase 5) ruff selects `PLR0911`, `PLR0912`, `PLR0913`, `PLR0915`, `PLR1702`, with `preview = true` enabled so `PLR1702` is active, and the tree passes. The counters are guardrails for future code. `PLR0911` surfaced one violation, `_check_call` in `tools/check_encoding.py` (a directory the analysis did not cover): a flat dispatch `C901` already passes, documented with a per-line noqa. The others flag nothing. (stated)
3. (#213, phase 6) ruff selects `ANN`, ignores `ANN401`, adds `ANN` to the `tests/**` per-file-ignores, and the tree passes. Real work: 3 annotations in src. (stated)
4. (#214, phase 7) ruff selects `S`, adds `S101` to the `tests/**` per-file-ignores, and the tree passes. Real work: the `ty` subprocess spawn in `refs.py` (`S603`, `S607`) and the `subprocess` import (`S404`, surfaced under preview, in `refs.py` and one test) are resolved or justified. (stated)
5. (#215, phase 8) ruff selects `PT` and `N`, and the tree passes. Real work: 2 `PT006` parametrize-name fixes and renaming the two exception classes `SymbolNotFound` and `UnsupportedNamePath` for `N818`. (stated)

### Preserved behaviour

- uncoded's product behaviour is unchanged: the index, stubs, docs map, `body`, and `refs` produce the same output. (assumed)
- The currently selected families stay selected: `D`, `E`, `F`, `I`, `UP`, `B`, `SIM`, `C901`, `W`, `C4`, `PIE`, `FLY`, `PERF`, `RUF`, `PLE`, `PLW2901`, `PLC0415`, `TC`, `TID`, `PTH`. (stated)
- CI keeps gating via `pre-commit run --all-files`; the 100% branch-coverage gate, the pep257 docstring convention, and the `tests/** = ["D"]` ignore stay in force (extended, not replaced). (stated)
- The two exception classes keep their raise/catch behaviour and messages. The rename updates every reference (cli, body, tests, docstrings). They stay internal, not re-exported. (assumed)

### Constraints

- Complexity threshold. `max-complexity` stays at 8. #207 authorises raising it to 10 only if a new rule genuinely fights `C901`. The one `PLR0911` violation was handled with a per-line noqa rather than a threshold change, so this did not arise. (stated, #207)
- Preview mode. `preview = true` is enabled. The project pins ruff to v0.15.19, so the preview rule set is fixed until a deliberate bump. Caveat: AGENTS.md's `uvx ruff` runs the latest ruff, so local preview rules can drift from the pinned CI hook on a future release. (stated)

### Out of session

#216 (complexipy, cognitive complexity) is a separate tool and not in this branch's issue set. Out of session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- dream:3.5.1 type:maintenance req:0 ca:0 scope:0 design:0 plan:0 challenge:no autopilot:from-code-analysis -->

