### PR TITLE
Add cognitive complexity check (complexipy)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
         entry: uv run ty check src tests
         language: system
         pass_filenames: false
+      - id: complexipy
+        name: complexipy
+        entry: uv run complexipy src tests
+        language: system
+        pass_filenames: false
       # Runs before uncoded so the generated skill files are built from
       # already-formatted sources. The generated skill dirs are excluded
       # because uncoded sync owns those files.

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -114,6 +114,7 @@ src/:
       _skill_path:
       _render_content:
       _remove_skill_file:
+      _sync_one_skill:
       sync_skills:
     stubs.py:
       VALUE_WIDTH_CAP:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -100,6 +100,7 @@ src/:
       UnsupportedNamePathError:
       resolve_ast_node:
       resolve_name_position:
+      _top_level_match:
       resolve_ast_node_from_source:
       _resolve_class_member:
     skill.py:
@@ -197,6 +198,7 @@ tests/:
       test_shadowed_class_member_found_in_last_definition:
       test_shadowed_class_member_not_found_in_last_definition:
       test_not_found_in_class:
+      test_class_member_found_when_function_has_same_head_name:
     TestUnsupportedNamePathError:
       SUPPORTED_SHAPES:
       _assert_raises:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -142,6 +142,8 @@ src/:
         constants:
         classes:
         functions:
+      _unparse_or_none:
+      _args_to_params:
       _extract_params:
       _render_value:
       _extract_assignment:

--- a/.uncoded/namespace.yaml
+++ b/.uncoded/namespace.yaml
@@ -34,6 +34,7 @@ src/:
         doc_roots:
       find_pyproject_toml:
       _has_uncoded_section:
+      _config_file_at:
       _find_config_file:
       read_config:
     docs_map.py:

--- a/.uncoded/stubs/src/uncoded/config.pyi
+++ b/.uncoded/stubs/src/uncoded/config.pyi
@@ -11,6 +11,9 @@ def find_pyproject_toml(start: Path) -> Path | None:
 def _has_uncoded_section(*, pyproject_path: Path) -> bool:
     ...
 
+def _config_file_at(*, directory: Path) -> Path | None:
+    ...
+
 def _find_config_file(*, start: Path) -> Path | None:
     ...
 

--- a/.uncoded/stubs/src/uncoded/resolver.pyi
+++ b/.uncoded/stubs/src/uncoded/resolver.pyi
@@ -13,6 +13,9 @@ def resolve_ast_node(name_path: NamePath, in_path: Path) -> ast.stmt:
 def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]:
     ...
 
+def _top_level_match(*, node: ast.stmt, head: str, tail: str | None) -> bool:
+    ...
+
 def resolve_ast_node_from_source(*, name_path: NamePath, source: str, in_path: Path) -> ast.stmt:
     ...
 

--- a/.uncoded/stubs/src/uncoded/skill.pyi
+++ b/.uncoded/stubs/src/uncoded/skill.pyi
@@ -21,6 +21,9 @@ def _render_content(*, skill: Skill) -> str:
 def _remove_skill_file(*, path: Path, project_root: Path, check: bool) -> bool:
     ...
 
+def _sync_one_skill(*, skill: Skill, source: bool, docs: bool, project_root: Path, check: bool) -> int:
+    ...
+
 def sync_skills(*, source: bool, docs: bool, project_root: Path, check: bool) -> int:
     ...
 

--- a/.uncoded/stubs/src/uncoded/stubs.pyi
+++ b/.uncoded/stubs/src/uncoded/stubs.pyi
@@ -11,6 +11,12 @@ from uncoded.sync import remove_file, sync_file
 
 VALUE_WIDTH_CAP = 80
 
+def _unparse_or_none(*, node: ast.expr | None) -> str | None:
+    ...
+
+def _args_to_params(*, arg_nodes: list[ast.arg]) -> list[StubParam]:
+    ...
+
 def _extract_params(args: ast.arguments) -> list[StubParam]:
     ...
 

--- a/.uncoded/stubs/tests/test_body.pyi
+++ b/.uncoded/stubs/tests/test_body.pyi
@@ -76,6 +76,9 @@ class TestResolveBodyClassMember:
     def test_not_found_in_class(self, tmp_path):
         ...
 
+    def test_class_member_found_when_function_has_same_head_name(self, tmp_path):
+        ...
+
 class TestUnsupportedNamePathError:
     SUPPORTED_SHAPES = ("'name'", "'Class/member'")
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,9 @@ pull request and will fail a build where a hook was skipped.
 Do not pass `--unsafe-fixes` unless a specific violation needs it and you have
 reviewed the change.
 
-A C901 violation means a function is too complex to pass the check. Refactor or
-flatten it rather than raising the `max-complexity` threshold.
+A complexity-check violation means a function is too complex to pass. Refactor
+or flatten it. Never suppress a violation with an ignore comment and never raise
+the threshold. The enabled checks and their thresholds are in `pyproject.toml`.
 
 The ty pre-commit hook runs the type checker. It is pinned via the `dev`
 optional dependency, the same way ruff is.
@@ -158,9 +159,9 @@ Run tests locally as `PYTHONWARNDEFAULTENCODING=1 uv run pytest`. The sentinel
 in `tests/test_encoding_gate.py` fails loudly if either the env var is unset or
 the filterwarnings escalation is removed.
 
-**Complexity ceiling.** The value is in `[tool.ruff.lint.mccabe]` in
-`pyproject.toml`. See [Linting and formatting](#linting-and-formatting) for the
-response to a C901 violation.
+**Complexity ceiling.** The enabled complexity checks and their thresholds are
+in `pyproject.toml`. See [Linting and formatting](#linting-and-formatting) for
+the response to a violation.
 
 **Index committed.** Commit `.uncoded/` and keep it current with the pre-commit
 hook. See [Commands](#commands) and [Dev setup](#dev-setup).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,8 +107,9 @@ Do not pass `--unsafe-fixes` unless a specific violation needs it and you have
 reviewed the change.
 
 A complexity-check violation means a function is too complex to pass. Refactor
-or flatten it. Never suppress a violation with an ignore comment and never raise
-the threshold. The enabled checks and their thresholds are in `pyproject.toml`.
+or flatten it. Never suppress a complexity violation with an ignore comment and
+never raise the threshold. The enabled checks and their thresholds are in
+`pyproject.toml`.
 
 The ty pre-commit hook runs the type checker. It is pinned via the `dev`
 optional dependency, the same way ruff is.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+    "complexipy==5.6.1",
     "hypothesis>=6.0",
     "pre-commit>=3.0",
     "pytest>=8.0",
@@ -109,6 +110,9 @@ ignore = [
 
 [tool.ruff.lint.mccabe]
 max-complexity = 8
+
+[tool.complexipy]
+max-complexity-allowed = 15
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/src/uncoded/config.py
+++ b/src/uncoded/config.py
@@ -45,9 +45,17 @@ def _has_uncoded_section(*, pyproject_path: Path) -> bool:
 def _config_file_at(*, directory: Path) -> Path | None:
     """Return the config file in ``directory``, or None.
 
-    Skips directories named ``.uncoded``. Raises :exc:`ConfigError` when
-    both ``pyproject.toml`` with ``[tool.uncoded]`` and ``.uncoded.toml``
-    are present in the same directory.
+    Skips directories named ``.uncoded``. Per-directory resolution rules:
+
+    - ``pyproject.toml`` with ``[tool.uncoded]`` AND ``.uncoded.toml`` both
+      present → raises :exc:`ConfigError` (configure uncoded in one file only).
+    - Only ``pyproject.toml`` with ``[tool.uncoded]`` → home is the pyproject.
+    - Only ``.uncoded.toml`` → home is the ``.uncoded.toml``.
+    - ``pyproject.toml`` without ``[tool.uncoded]``, no ``.uncoded.toml``
+      → home is the pyproject (bare Python project; roots default to empty).
+    - ``pyproject.toml`` without ``[tool.uncoded]`` AND ``.uncoded.toml``
+      → home is the ``.uncoded.toml`` (bare pyproject does not shadow it).
+    - Neither file → returns None.
     """
     if directory.name == ".uncoded":
         return None
@@ -74,20 +82,9 @@ def _config_file_at(*, directory: Path) -> Path | None:
 def _find_config_file(*, start: Path) -> Path | None:
     """Return the nearest config file walking up from ``start``.
 
-    Discovery rules at each directory (skipping directories named ``.uncoded``):
-
-    - ``pyproject.toml`` with ``[tool.uncoded]`` AND ``.uncoded.toml`` both
-      present → raises :exc:`ConfigError` (ambiguous; configure in one file).
-    - Only ``pyproject.toml`` with ``[tool.uncoded]`` → home is the pyproject.
-    - Only ``.uncoded.toml`` → home is the ``.uncoded.toml``.
-    - ``pyproject.toml`` without ``[tool.uncoded]``, no ``.uncoded.toml``
-      → home is the pyproject (bare Python project; roots default to empty).
-    - ``pyproject.toml`` without ``[tool.uncoded]`` AND ``.uncoded.toml``
-      → home is the ``.uncoded.toml`` (bare pyproject does not shadow it).
-    - Neither file → keep walking up.
-
-    When the two file types sit at different walk levels, the nearer one wins
-    with no error. Ambiguity is only a same-directory condition.
+    The nearest directory with a result wins. Ambiguity is a same-directory
+    condition only. Files at different levels do not conflict. Returns None
+    when no config file is found.
     """
     start_resolved = start.resolve()
     for directory in [start_resolved, *start_resolved.parents]:
@@ -101,11 +98,10 @@ def read_config(start: Path) -> Config:
     """Locate the config file and read all uncoded settings from it.
 
     Walks up from ``start`` looking for ``pyproject.toml`` or
-    ``.uncoded.toml`` (see ``_find_config_file`` for precedence rules).
-    Raises :exc:`ConfigError` when no config file is found, or when two
-    config files in the same directory both configure uncoded. A found
-    config file with no uncoded settings returns a Config with empty root
-    lists.
+    ``.uncoded.toml``. Raises :exc:`ConfigError` when no config file is
+    found, or when two config files in the same directory both configure
+    uncoded. A found config file with no uncoded settings returns a Config
+    with empty root lists.
     """
     config_file = _find_config_file(start=start)
     if config_file is None:

--- a/src/uncoded/config.py
+++ b/src/uncoded/config.py
@@ -42,6 +42,35 @@ def _has_uncoded_section(*, pyproject_path: Path) -> bool:
         return False
 
 
+def _config_file_at(*, directory: Path) -> Path | None:
+    """Return the config file in ``directory``, or None.
+
+    Skips directories named ``.uncoded``. Raises :exc:`ConfigError` when
+    both ``pyproject.toml`` with ``[tool.uncoded]`` and ``.uncoded.toml``
+    are present in the same directory.
+    """
+    if directory.name == ".uncoded":
+        return None
+    pyproject = directory / "pyproject.toml"
+    uncoded_toml = directory / ".uncoded.toml"
+    has_uncoded_toml = uncoded_toml.exists()
+    if pyproject.exists():
+        has_section = _has_uncoded_section(pyproject_path=pyproject)
+        if has_section and has_uncoded_toml:
+            raise ConfigError(
+                "Ambiguous config: both pyproject.toml and .uncoded.toml "
+                "configure uncoded in the same directory. "
+                "Configure uncoded in one file only."
+            )
+        if not has_section and has_uncoded_toml:
+            # Bare pyproject does not shadow a sibling .uncoded.toml.
+            return uncoded_toml
+        return pyproject
+    if has_uncoded_toml:
+        return uncoded_toml
+    return None
+
+
 def _find_config_file(*, start: Path) -> Path | None:
     """Return the nearest config file walking up from ``start``.
 
@@ -60,30 +89,12 @@ def _find_config_file(*, start: Path) -> Path | None:
     When the two file types sit at different walk levels, the nearer one wins
     with no error. Ambiguity is only a same-directory condition.
     """
-    current = start.resolve()
-    while True:
-        if current.name != ".uncoded":
-            pyproject = current / "pyproject.toml"
-            uncoded_toml = current / ".uncoded.toml"
-            has_uncoded_toml = uncoded_toml.exists()
-            if pyproject.exists():
-                has_section = _has_uncoded_section(pyproject_path=pyproject)
-                if has_section and has_uncoded_toml:
-                    raise ConfigError(
-                        "Ambiguous config: both pyproject.toml and .uncoded.toml "
-                        "configure uncoded in the same directory. "
-                        "Configure uncoded in one file only."
-                    )
-                if not has_section and has_uncoded_toml:
-                    # Bare pyproject does not shadow a sibling .uncoded.toml.
-                    return uncoded_toml
-                return pyproject
-            if has_uncoded_toml:
-                return uncoded_toml
-        parent = current.parent
-        if parent == current:
-            return None
-        current = parent
+    start_resolved = start.resolve()
+    for directory in [start_resolved, *start_resolved.parents]:
+        result = _config_file_at(directory=directory)
+        if result is not None:
+            return result
+    return None
 
 
 def read_config(start: Path) -> Config:

--- a/src/uncoded/resolver.py
+++ b/src/uncoded/resolver.py
@@ -86,6 +86,31 @@ def resolve_name_position(name_path: NamePath, in_path: Path) -> tuple[int, int]
     )
 
 
+def _top_level_match(
+    *,
+    node: ast.stmt,
+    head: str,
+    tail: str | None,
+) -> bool:
+    """Return True if node matches head as a top-level symbol.
+
+    ClassDef matches regardless of tail (it is the dispatch target for
+    class-member lookups). Function, assignment, and type-alias nodes
+    match only when tail is None.
+    """
+    if isinstance(node, ast.ClassDef):
+        return node.name == head
+    if tail is not None:
+        return False
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return node.name == head
+    if isinstance(node, (ast.Assign, ast.AnnAssign)):
+        return assign_target_name(node) == head
+    if isinstance(node, ast.TypeAlias):
+        return node.name.id == head
+    return False
+
+
 def resolve_ast_node_from_source(
     *,
     name_path: NamePath,
@@ -108,19 +133,9 @@ def resolve_ast_node_from_source(
     top_match: ast.stmt | None = None
 
     for node in ast.iter_child_nodes(tree):
-        matches_class = isinstance(node, ast.ClassDef) and node.name == head
-        matches_function = (
-            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and tail is None
-            and node.name == head
-        )
-        if matches_class or matches_function:
-            top_match = node
-        elif isinstance(node, (ast.Assign, ast.AnnAssign)) and tail is None:
-            name = assign_target_name(node)
-            if name == head:
-                top_match = node
-        elif isinstance(node, ast.TypeAlias) and tail is None and node.name.id == head:
+        if isinstance(node, ast.stmt) and _top_level_match(
+            node=node, head=head, tail=tail
+        ):
             top_match = node
 
     if top_match is None:

--- a/src/uncoded/skill.py
+++ b/src/uncoded/skill.py
@@ -100,6 +100,46 @@ def _remove_skill_file(*, path: Path, project_root: Path, check: bool) -> bool:
     return removed
 
 
+def _sync_one_skill(
+    *,
+    skill: Skill,
+    source: bool,
+    docs: bool,
+    project_root: Path,
+    check: bool,
+) -> int:
+    """Build or remove one skill's files, then remove any legacy names.
+
+    Returns the number of file changes (writes and removals).
+    """
+    changes = 0
+    build = source if skill.gate == "code" else docs
+    if build:
+        content = _render_content(skill=skill)
+        for root in SKILL_ROOTS:
+            changes += sync_file(
+                _skill_path(root, skill.name),
+                content,
+                project_root=project_root,
+                check=check,
+            )
+    else:
+        for root in SKILL_ROOTS:
+            changes += _remove_skill_file(
+                path=_skill_path(root, skill.name),
+                project_root=project_root,
+                check=check,
+            )
+    for legacy_name in skill.legacy_names:
+        for root in SKILL_ROOTS:
+            changes += _remove_skill_file(
+                path=_skill_path(root, legacy_name),
+                project_root=project_root,
+                check=check,
+            )
+    return changes
+
+
 def sync_skills(
     *,
     source: bool,
@@ -117,28 +157,11 @@ def sync_skills(
     """
     changes = 0
     for skill in SKILLS:
-        build = source if skill.gate == "code" else docs
-        if build:
-            content = _render_content(skill=skill)
-            for root in SKILL_ROOTS:
-                changes += sync_file(
-                    _skill_path(root, skill.name),
-                    content,
-                    project_root=project_root,
-                    check=check,
-                )
-        else:
-            for root in SKILL_ROOTS:
-                changes += _remove_skill_file(
-                    path=_skill_path(root, skill.name),
-                    project_root=project_root,
-                    check=check,
-                )
-        for legacy_name in skill.legacy_names:
-            for root in SKILL_ROOTS:
-                changes += _remove_skill_file(
-                    path=_skill_path(root, legacy_name),
-                    project_root=project_root,
-                    check=check,
-                )
+        changes += _sync_one_skill(
+            skill=skill,
+            source=source,
+            docs=docs,
+            project_root=project_root,
+            check=check,
+        )
     return changes

--- a/src/uncoded/stubs.py
+++ b/src/uncoded/stubs.py
@@ -68,37 +68,48 @@ class StubModule:
     functions: list[StubFunction] = field(default_factory=list)
 
 
+def _unparse_or_none(*, node: ast.expr | None) -> str | None:
+    """Unparse an optional annotation node, returning None when absent."""
+    return ast.unparse(node) if node else None
+
+
+def _args_to_params(*, arg_nodes: list[ast.arg]) -> list[StubParam]:
+    """Convert a list of AST argument nodes to StubParam records."""
+    return [
+        StubParam(name=a.arg, annotation=_unparse_or_none(node=a.annotation))
+        for a in arg_nodes
+    ]
+
+
 def _extract_params(args: ast.arguments) -> list[StubParam]:
     """Extract parameters from a function argument node, without defaults."""
     params: list[StubParam] = []
 
-    for arg in args.posonlyargs:
-        annotation = ast.unparse(arg.annotation) if arg.annotation else None
-        params.append(StubParam(name=arg.arg, annotation=annotation))
+    params.extend(_args_to_params(arg_nodes=args.posonlyargs))
     if args.posonlyargs:
         params.append(StubParam(name="/"))
 
-    for arg in args.args:
-        annotation = ast.unparse(arg.annotation) if arg.annotation else None
-        params.append(StubParam(name=arg.arg, annotation=annotation))
+    params.extend(_args_to_params(arg_nodes=args.args))
 
     if args.vararg:
-        annotation = (
-            ast.unparse(args.vararg.annotation) if args.vararg.annotation else None
+        params.append(
+            StubParam(
+                name=f"*{args.vararg.arg}",
+                annotation=_unparse_or_none(node=args.vararg.annotation),
+            )
         )
-        params.append(StubParam(name=f"*{args.vararg.arg}", annotation=annotation))
     elif args.kwonlyargs:
         params.append(StubParam(name="*"))
 
-    for arg in args.kwonlyargs:
-        annotation = ast.unparse(arg.annotation) if arg.annotation else None
-        params.append(StubParam(name=arg.arg, annotation=annotation))
+    params.extend(_args_to_params(arg_nodes=args.kwonlyargs))
 
     if args.kwarg:
-        annotation = (
-            ast.unparse(args.kwarg.annotation) if args.kwarg.annotation else None
+        params.append(
+            StubParam(
+                name=f"**{args.kwarg.arg}",
+                annotation=_unparse_or_none(node=args.kwarg.annotation),
+            )
         )
-        params.append(StubParam(name=f"**{args.kwarg.arg}", annotation=annotation))
 
     return params
 
@@ -153,7 +164,7 @@ def _extract_function(
     return StubFunction(
         name=node.name,
         params=_extract_params(node.args),
-        return_annotation=ast.unparse(node.returns) if node.returns else None,
+        return_annotation=_unparse_or_none(node=node.returns),
         is_async=isinstance(node, ast.AsyncFunctionDef),
     )
 
@@ -164,7 +175,7 @@ def _property_attribute(
     """Build a StubAssignment representing a @property as a class attribute."""
     return StubAssignment(
         name=node.name,
-        annotation=ast.unparse(node.returns) if node.returns else None,
+        annotation=_unparse_or_none(node=node.returns),
     )
 
 

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -298,14 +298,15 @@ class TestResolveBodyClassMember:
             resolve_body(NamePath("Foo", "missing"), path)
 
     def test_class_member_found_when_function_has_same_head_name(self, tmp_path):
-        # A top-level function sharing the class name must not block the
-        # class-member dispatch when the name_path carries a tail.
+        # The function comes AFTER the class so a broadened predicate that
+        # wrongly matches the function would latch it as the last match,
+        # making the tail dispatch see a function instead of a class and fail.
         source = textwrap.dedent("""\
-            def Foo(): pass
-
             class Foo:
                 def member(self):
                     pass
+
+            def Foo(): pass
         """)
         path = tmp_path / "m.py"
         path.write_text(source, encoding="utf-8")

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -297,6 +297,23 @@ class TestResolveBodyClassMember:
         with pytest.raises(SymbolNotFoundError, match="missing"):
             resolve_body(NamePath("Foo", "missing"), path)
 
+    def test_class_member_found_when_function_has_same_head_name(self, tmp_path):
+        # A top-level function sharing the class name must not block the
+        # class-member dispatch when the name_path carries a tail.
+        source = textwrap.dedent("""\
+            def Foo(): pass
+
+            class Foo:
+                def member(self):
+                    pass
+        """)
+        path = tmp_path / "m.py"
+        path.write_text(source, encoding="utf-8")
+
+        result = resolve_body(NamePath("Foo", "member"), path)
+
+        assert result == "    def member(self):\n        pass\n"
+
 
 class TestUnsupportedNamePathError:
     SUPPORTED_SHAPES = ("'name'", "'Class/member'")

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -18,6 +27,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "complexipy"
+version = "5.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/eb/05793bd709220b0d12508e8d7b7fc8b0d7c020ce443588af3724aa494a4a/complexipy-5.6.1.tar.gz", hash = "sha256:c87e931e648eddab5f4b9eb1fcbbc7cf6de5840f7d8d65b6ae49364b0d9b561d", size = 351568, upload-time = "2026-06-16T02:22:49.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/4b/5926e05a8cb01d93b127cb13e56cd3b5def3a6ae26766129e19d0fa3c332/complexipy-5.6.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bab111bc6a99a05d0a6eef1117c6ca6c708098f81d16cc3b0feeb4981648fdd4", size = 2326174, upload-time = "2026-06-16T02:20:21.7Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/46/10397005f309a11369c34a6bce66c3bcffef0a02ceaf3026f167ff947487/complexipy-5.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7aa4ae292c8149ee28f9b3ae778000a405482ec78b21f487b486bfa5b92d5118", size = 2260654, upload-time = "2026-06-16T02:20:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/33/bf/e3defcc178dcb8079f7d562e35a734f076b2a82d822ac86f875912433494/complexipy-5.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35751bd6dc8e9ca5205a8f4863d090eb1c267ebd53c8bf0fbba1a4992612363d", size = 2445038, upload-time = "2026-06-16T02:20:25.399Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ae/94793b90decd3d946edb6f301b9b62bdb3f98909857bae8aa8169d922f9f/complexipy-5.6.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e6e39eca5d48eb0cc4a5cf1327dde3ee5c940edc815c98113888be98bff04f6", size = 2376048, upload-time = "2026-06-16T02:20:27.216Z" },
+    { url = "https://files.pythonhosted.org/packages/93/43/92410b8a9b78087375d1ab511cff7027b29a4b129c343c1ff8f7af394028/complexipy-5.6.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:051e59ddd7db5b3336d5eca905825f9edbf0b1e8360694b79a3cb2def0ac49f6", size = 2585919, upload-time = "2026-06-16T02:20:29.011Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/745d0783a05ddaac160d470b1cd19b0ea943fcb3baab1401d966b9367b15/complexipy-5.6.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b84713d51619bb7c9bdc67b17ab23688c83444a39c04f4a7c65fb8de17079bf", size = 2823263, upload-time = "2026-06-16T02:20:30.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cc/cf5219ab0e6a694c3e5f1dda29cea2ed18cb1c798e19e9b494f77a4649ff/complexipy-5.6.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61b6367fd94e40715a749ff3288d9b2e0e5418d71d26aa95a220ecf85e324561", size = 2503972, upload-time = "2026-06-16T02:20:32.32Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9d/1b3d1434e3f27cc2524fddff5ef546d3a8d2d84f5a93c2ff5e06f863ab40/complexipy-5.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:642343d24e0a12dce0fef4ec7eccc9c26703514e7318a8143c0b00e37a909d9f", size = 2485910, upload-time = "2026-06-16T02:20:34.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f0/d175eca1e6fceb7ac6808b134b5e53a1acfbff0afd09ed24963147c5acaa/complexipy-5.6.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e049f7dffb69f89544be5c91e97ae128f44844b75d8012f97a628ee2ad6b4ce6", size = 2620506, upload-time = "2026-06-16T02:20:36.088Z" },
+    { url = "https://files.pythonhosted.org/packages/af/0d/89d3df43f73867172269ceccfc0ed6b75ec584efdf4bbe62d66541634527/complexipy-5.6.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4f17a5473453da257823b25fc4277a903ea3806906bc97caa56595cf86ccc749", size = 2716663, upload-time = "2026-06-16T02:20:37.864Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9a/c451aedb8b35070570fb201050e0084588e7565471816d420809a836678e/complexipy-5.6.1-cp312-cp312-win32.whl", hash = "sha256:a2d5fd3b70f2656522197ff9c6503ef0a30709b90ec35c533685856941312f60", size = 2022213, upload-time = "2026-06-16T02:20:39.528Z" },
+    { url = "https://files.pythonhosted.org/packages/20/40/268ee2fecdbae9d8f11981055b871f0dcf0f4fb7cc85088f26229adb8a79/complexipy-5.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:137b728fad70d406cdb4648f9f0b0f76d0be36e58aafd2c95d33df0101a32476", size = 2181078, upload-time = "2026-06-16T02:20:41.352Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/b0db58966138a228678ed0786d0d39d110bd2f82d002ef8265f234b8a147/complexipy-5.6.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ada152ea84939c73eeda354b25ea705f48b26dcd53723a67ffc57101efb60669", size = 2324665, upload-time = "2026-06-16T02:20:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/6c/eeb78a9d1a51f2afbd6c608da2e60d7ca3d07082c206c23c5fb058ac2047/complexipy-5.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3f9d62c7ba7741bf6cface8909233a7b2327feca8b216e804ff8208f9a887a8e", size = 2259574, upload-time = "2026-06-16T02:20:45.124Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/e40516ca63c966a2bbc1c98bfe66d978d8619874c1a98718eddcb41d811b/complexipy-5.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c01cfed97ba72e4f1e0d6e264cd5b5aeef85e27bf5e33e8f2479be6094481c0", size = 2444111, upload-time = "2026-06-16T02:20:47.151Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e5/b354290199f00b741e8b155f2e3bfbd3849116663b877e32b76f11a0d360/complexipy-5.6.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:85369a9ee250eda48960fff0c6d5e3f5ecabc78e67623d1059d54eb45ddf7b81", size = 2376082, upload-time = "2026-06-16T02:20:49.153Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cd/709103bdbeab8b84a9348f5fa84cbc4dbb9d76165934220ddd817bbde6a4/complexipy-5.6.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bcb67f54db7760a7d30ce37c9b7994553a2ff47b0f70a7b32d1bf078edfd1e95", size = 2585895, upload-time = "2026-06-16T02:20:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c9/28d33afa53b960ece55c420cb86abbada33cce69e0bc9f43ca1c6d2db812/complexipy-5.6.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f59b757c86629433dc1ca4e925193660f76a5b2c55ad64b8fdaa5327f53f45a4", size = 2823039, upload-time = "2026-06-16T02:20:52.757Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a6/68f7dfe8f4fcdd9cc87b15e9a3302b6ea5be547e829365d7ff47d0547ac2/complexipy-5.6.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7d80af8f812d80c0e02c95d827bbb5eef9525ba4d563b97d86668ab9c6422f9e", size = 2504637, upload-time = "2026-06-16T02:20:54.893Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7c/edb909b45fdfea46d2c4b1d7bbaece3490571ea00b400d2e8977785f1f00/complexipy-5.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb0507914054a9b4b06cc7db3aa169198ba0a33f794598e1c92e43088989cdf3", size = 2485559, upload-time = "2026-06-16T02:20:56.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e3/eccb2cc5a6396495aace775c5feec966e3a613be1e1af0e31365a126b128/complexipy-5.6.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:08eaaa0306584a79841c5933b375729912def8510d72ac6ebbf1338e3ce22bcd", size = 2619754, upload-time = "2026-06-16T02:20:58.447Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/66/930386a4ec43e02fadf0b30106c2a3501c1a6c2035ef20f0cf2777cf9090/complexipy-5.6.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c34e7be0c1106f0bd6015ff9ed44530254892f5d5f3cd85ccb1f41132a7a1e3a", size = 2715953, upload-time = "2026-06-16T02:21:00.25Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/6b1e830753b20f03b0229dc99fefbd8af77199f7bd6e363b50513464eae0/complexipy-5.6.1-cp313-cp313-win32.whl", hash = "sha256:b3ad3631cc911e6c58dbee2aac7ccff36dfe141810a87041b6cf834ad23f9198", size = 2021541, upload-time = "2026-06-16T02:21:02.022Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b9cb8609b20832d15747054cac1080c8cefac3e3019d37862037d002a0e9/complexipy-5.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:600ed75e2e38b58b46d9c0237a726fb23bb0036011d1fa5493eec4aa3639a5dc", size = 2180749, upload-time = "2026-06-16T02:21:03.931Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c5/61148f045f24a5da714142df14744598fe0aed9d1a655a32f3641ab00af6/complexipy-5.6.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:28b09a319b679a5d12c2886f3f02ad2f33a6bcabadd4bb5277dc74f2b72f78e8", size = 2326948, upload-time = "2026-06-16T02:21:05.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b0/dd1240297c7eda8e718e15343d16461a40f2d26a8b38a095406e443dc1e0/complexipy-5.6.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5af3feb5d7d43736cad13265d0225f79aea22012d19f18e3cb09aa9bb480c924", size = 2261192, upload-time = "2026-06-16T02:21:07.29Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/9480ae4e3ab9ddb239fea7d0dfd500f11c1fe08001e672a0e541be029336/complexipy-5.6.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89769c502c4a4df8b6b535d3ee234755f14337589b0559b28fc27b9029331ad8", size = 2446418, upload-time = "2026-06-16T02:21:09.069Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1c/30b110becf97c81ffc3c1c243d447b4b9c4d6ce129faf8ee5e065c8311ae/complexipy-5.6.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c728f128101f1b94cf1d23868a074d19e0c4996fd196d52fbd68f34df849156", size = 2375977, upload-time = "2026-06-16T02:21:10.764Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c9/e16642e6858125b999bb7c177ef807a79f335967f9fca978c3e790013b62/complexipy-5.6.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae127e5854ab7c883818fc9bb6d9074e2949f5a52fa4e64182c4e917b19aacd6", size = 2585597, upload-time = "2026-06-16T02:21:12.458Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/2a/b0213a8f5216034ff7f5244dd3563766c1c1b5fc9860c4eae0d49acd27ec/complexipy-5.6.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:173ccadf3fe7dbe373a69d2c896848512f2aa3533f5282bb5514d20234a51cf8", size = 2825346, upload-time = "2026-06-16T02:21:14.362Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/87/f0d3d165c9a34c4bbf9f560dcfbc492fa3bfaeb888b78c279fb791ab29a6/complexipy-5.6.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d2a12d0beef432cec4c8cbf2321f92209aefa6837a7517538e9aef71bddaca2f", size = 2504559, upload-time = "2026-06-16T02:21:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/57/46c8ae2a2265929be87c1fcf7576435303268a8ee1ac4040dfd059945a94/complexipy-5.6.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a4f3559a74df2b7ed0738a1bdf2c64ffb1d020f11bacb96973ab7c1a53a3ff0", size = 2486083, upload-time = "2026-06-16T02:21:17.874Z" },
+    { url = "https://files.pythonhosted.org/packages/08/5d/3a97e6d36ca4bcb1fc88ac7068d2d4c7878247e879d7229e1f39b33ee3ce/complexipy-5.6.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bef7953fb9b823465ea883b1cc80c5e598977553ed3d28b091b06f9a4a6e437b", size = 2621455, upload-time = "2026-06-16T02:21:19.818Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e6/c70ef71dc4f7380a71757c86f226b8d149ad9638ef61e169c0a250df6b81/complexipy-5.6.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c443fbf310b86897ac22c6895d8bfb3e936cc96603667e20bfa79136b5e3bf31", size = 2716093, upload-time = "2026-06-16T02:21:21.917Z" },
+    { url = "https://files.pythonhosted.org/packages/59/25/0ff066509d78ac4281f9dfd790c7a6c4220d0b7e93f51e194cfc4eed2a7d/complexipy-5.6.1-cp314-cp314-win32.whl", hash = "sha256:db8c378b2b79c63c3ab05a5824ddffdf5cf6d0df075cc5e7dc6dcb410f560f84", size = 2023468, upload-time = "2026-06-16T02:21:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/aa/e9a97bfde6164671fb072540bedde9a0d01dedfa60f53278701c87329526/complexipy-5.6.1-cp314-cp314-win_amd64.whl", hash = "sha256:fed55f0e58a3d232f4cda44405b3036fa744a2c6e5ff39bc756b050f8187cb02", size = 2180897, upload-time = "2026-06-16T02:21:26.053Z" },
+    { url = "https://files.pythonhosted.org/packages/79/31/e0db7b5d72d099e4fcff7e47d8f52eafadeab1c8564463007d339c3c9a9a/complexipy-5.6.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bdd2da5704e43d285870b8fb4665e0441e7986fb52d2ce447fc2e81f1e8fef60", size = 2445960, upload-time = "2026-06-16T02:21:28.629Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/e09d3e046c9cd6cb94af2bce78cbc9ac1f0795f6292c4d7233d275c6c312/complexipy-5.6.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6bf7095add83cee9a1f0f36e95132f4384db8a1a2bd8a26fe680f5fcc018b7d", size = 2374784, upload-time = "2026-06-16T02:21:30.406Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/7e67b5d4be537500a5b5f7a212bb3c0e7cff5591d05e7eae41e78b3390ad/complexipy-5.6.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82db8a861d2a347a7549bf37dbaadb845b93cc60eee259020a3cb31827b2ef28", size = 2585969, upload-time = "2026-06-16T02:21:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/439836b43e60fcb428e954da20db3270fffc0fbf9c6fd838f42e27fe9bcd/complexipy-5.6.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d450c6903f4242dea4a3036b34ee5c1d16449025676bdaf99b21780426fe3a9b", size = 2824562, upload-time = "2026-06-16T02:21:34.081Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e8/31468ead513e62ffc11e7560fd1051a42becbe32f3652dc5b92d345cf10c/complexipy-5.6.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3111a61cab06e7165dd758d1d8214a7d13b361d026df4879f23275687c7fedec", size = 2505532, upload-time = "2026-06-16T02:21:35.885Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/34cb550d29b34aaaf25c30bf53f593a2f93af62710bf0e2749c71fe48ec9/complexipy-5.6.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85a16cb1eb1dc759742663082b5fce4bf4fb89f016c145064ac2c5ecc6bddd8b", size = 2487428, upload-time = "2026-06-16T02:21:37.796Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/71/a21b829f0a72e4ba94c51ee70f4e688c8d9a19f5e8015a0acfc829329d1b/complexipy-5.6.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:78033fb47f9cbb65a101dc4794df877da6b2b0012c4d0201f253313c197e9dd2", size = 2621691, upload-time = "2026-06-16T02:21:39.58Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7b/09cb4a7abd4c628cd80c6b72a8df15f344b541ecb76beb070b6decd0e729/complexipy-5.6.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fcb3181e0c4887486465c37907366b54bb3ffaa7a4bf6ebcf814df75a8773c45", size = 2716826, upload-time = "2026-06-16T02:21:41.898Z" },
+    { url = "https://files.pythonhosted.org/packages/57/21/de26b13ef3073601d2a9a75de1143c46867928a582bc1ce0b3af0fb030b0/complexipy-5.6.1-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d028a14436f41a774d15cfa2104834542802337beed7da94f6f58475be3edc72", size = 2585882, upload-time = "2026-06-16T02:21:43.859Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ca/178de697abc9fbd7ced7f8f604cacfddafd599ea2df955d00786218fd77f/complexipy-5.6.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48e7c40022d82050f0751813f38c5df62f176d7ae29d2768a08b08a4903714e6", size = 2487429, upload-time = "2026-06-16T02:21:45.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/9f4f47c12b3a6f15fc6e05434662d3b3a5b51eb174ffd8dcbeb9655da8cd/complexipy-5.6.1-cp315-cp315t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc81a83e0de9b5621f9d39bba5950bc4410d966e33f39e24938145d607252bca", size = 2586449, upload-time = "2026-06-16T02:21:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/66/21/a881f11fe11295d651da54355376a3630b6505522911a4fbd5202a5b393d/complexipy-5.6.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1ab58ad3dd28b8c0e015e3777d8d0cdae6f1e047e64186272be62ca03c135c", size = 2487704, upload-time = "2026-06-16T02:21:49.121Z" },
 ]
 
 [[package]]
@@ -150,6 +219,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -303,6 +393,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.19"
 source = { registry = "https://pypi.org/simple" }
@@ -328,12 +431,66 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]
@@ -362,6 +519,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+]
+
+[[package]]
 name = "uncoded"
 source = { editable = "." }
 dependencies = [
@@ -370,6 +542,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "complexipy" },
     { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -380,6 +553,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "complexipy", marker = "extra == 'dev'", specifier = "==5.6.1" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
Adds a cognitive-complexity check to the pre-commit suite and refactors the functions that exceed it. Addresses #216.

Closes #216

## Requirements Analysis

Session Type: maintenance. It adds a static check (cognitive complexity, via complexipy) and refactors the functions that exceed it. Behaviour stays the same. It follows #204, which added the C901 cyclomatic check.

### Improvement goals

Each goal is a checkable property of the code.

1. A cognitive-complexity check (complexipy) runs at pre-commit, and so in CI, failing when any covered function scores above 15.
2. The check covers tests as well as source, matching the scope of the existing C901 cyclomatic check.
3. Every covered function scores at or below 15. The four current offenders are refactored, with no `# complexipy: ignore` suppression left behind: `_find_config_file` (21), `sync_skills` (17), `_extract_params` (17), `resolve_ast_node_from_source` (16).
4. The conventions section in `AGENTS.md` names the cognitive-complexity check beside the existing cyclomatic ceiling, and states how to judge a violation: refactor or flatten, never suppress or raise the threshold. This matches the C901 rule and closes the gap #226 raised about complexity counters accruing suppressions.
5. The hook is pinned to a current release, consistent with the repo's other pinned pre-commit hooks.

### Preserved behaviour

Refactoring the offenders preserves their behaviour. uncoded's generated outputs (`namespace.yaml`, stubs, `docs.yaml`, skills) and CLI behaviour are unchanged. The suite stays green at 100% branch coverage.

### Decided shape

An absolute threshold gated through the existing pre-commit hook, not complexipy's `--diff main --ratchet` CI recipe. The issue rejects ratchet as a poor fit for a small, fully-covered codebase run all-files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- dream:3.13.1 type:maintenance req:0 ca:0 scope:0 design:0 plan:0 challenge:no autopilot:from-code -->
